### PR TITLE
ci: fix semantic-release to work with branch protection

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,20 +3,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
     "@semantic-release/npm",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
Simplified semantic-release configuration to work with branch protection rules that require pull requests.

## Problem
The current semantic-release config uses `@semantic-release/git` which tries to push commits (CHANGELOG.md, package.json updates) directly to main after creating a release. This conflicts with the branch protection rule requiring all changes to go through PRs.

## Solution
Removed the following plugins:
- `@semantic-release/changelog` 
- `@semantic-release/git`

The release workflow will now:
- ✅ Analyze commits and determine version
- ✅ Publish to npm with provenance
- ✅ Create GitHub releases with release notes
- ❌ No longer commits CHANGELOG.md back to main (blocked by branch protection anyway)

This allows releases to publish successfully without conflicting with repository rules.

## Test plan
- [x] Configuration validated
- [ ] Will test on next merge to main