### PR TITLE
Fixes documents date format and adds invoiceNum field

### DIFF
--- a/src/__tests__/documents.test.ts
+++ b/src/__tests__/documents.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createMockClient } from './mock-client.js';
 import { getDocumentTools } from '../tools/documents.js';
+import { createDocumentSchema, updateDocumentSchema } from '../validation.js';
 
 describe('Document Tools', () => {
   let client: ReturnType<typeof createMockClient>;
@@ -108,6 +109,64 @@ describe('Document Tools', () => {
         currency: 'EUR',
       });
     });
+
+    it('should forward taxes arrays for purchase line items', async () => {
+      const args = {
+        docType: 'purchase' as const,
+        contactId: 'supplier-123',
+        invoiceNum: 'SUP-2026-001',
+        items: [
+          {
+            name: 'Gasto con IVA 21%',
+            units: 1,
+            subtotal: 100,
+            taxes: ['tax-21'],
+          },
+          {
+            name: 'Gasto con IVA 10%',
+            units: 1,
+            subtotal: 50,
+            taxes: ['tax-10'],
+          },
+        ],
+      };
+      await tools.create_document.handler(args);
+      expect(client.post).toHaveBeenCalledWith('/documents/purchase', {
+        contactId: 'supplier-123',
+        invoiceNum: 'SUP-2026-001',
+        items: [
+          {
+            name: 'Gasto con IVA 21%',
+            units: 1,
+            subtotal: 100,
+            taxes: ['tax-21'],
+          },
+          {
+            name: 'Gasto con IVA 10%',
+            units: 1,
+            subtotal: 50,
+            taxes: ['tax-10'],
+          },
+        ],
+      });
+    });
+
+    it('should reject purchase line items with more than one tax ID', () => {
+      expect(() =>
+        createDocumentSchema.parse({
+          docType: 'purchase',
+          contactId: 'supplier-123',
+          items: [
+            {
+              name: 'Gasto inválido',
+              units: 1,
+              subtotal: 100,
+              taxes: ['tax-21', 'tax-10'],
+            },
+          ],
+        })
+      ).toThrow();
+    });
   });
 
   describe('get_document', () => {
@@ -128,6 +187,28 @@ describe('Document Tools', () => {
       expect(client.put).toHaveBeenCalledWith('/documents/invoice/doc-123', {
         notes: 'Updated notes',
       });
+    });
+
+    it('should update purchase items with taxes arrays', async () => {
+      const args = {
+        docType: 'purchase' as const,
+        documentId: 'doc-123',
+        items: [{ name: 'Línea actualizada', units: 1, subtotal: 80, taxes: ['tax-21'] }],
+      };
+      await tools.update_document.handler(args);
+      expect(client.put).toHaveBeenCalledWith('/documents/purchase/doc-123', {
+        items: [{ name: 'Línea actualizada', units: 1, subtotal: 80, taxes: ['tax-21'] }],
+      });
+    });
+
+    it('should reject updated purchase items without required line fields', () => {
+      expect(() =>
+        updateDocumentSchema.parse({
+          docType: 'purchase',
+          documentId: 'doc-123',
+          items: [{ taxes: ['tax-21'] }],
+        })
+      ).toThrow();
     });
   });
 

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -232,6 +232,10 @@ export function getDocumentTools(client: HoldedClient) {
             type: 'string',
             description: 'Currency code (e.g., EUR, USD)',
           },
+          invoiceNum: {
+            type: 'string',
+            description: 'Document reference number (e.g. invoice number from supplier)',
+          },
         },
         required: ['docType', 'contactId', 'items'],
       },

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -329,6 +329,10 @@ export function getDocumentTools(client: HoldedClient) {
             type: 'string',
             description: 'Notes for the document',
           },
+          invoiceNum: {
+            type: 'string',
+            description: 'Document reference number (e.g. invoice number from supplier)',
+          },
           salesChannelId: {
             type: 'string',
             description: 'Sales channel ID to associate with the document',

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -236,6 +236,10 @@ export function getDocumentTools(client: HoldedClient) {
             type: 'string',
             description: 'Document reference number (e.g. invoice number from supplier)',
           },
+          salesChannelId: {
+            type: 'string',
+            description: 'Sales channel ID to associate with the document',
+          },
         },
         required: ['docType', 'contactId', 'items'],
       },
@@ -324,6 +328,10 @@ export function getDocumentTools(client: HoldedClient) {
           notes: {
             type: 'string',
             description: 'Notes for the document',
+          },
+          salesChannelId: {
+            type: 'string',
+            description: 'Sales channel ID to associate with the document',
           },
         },
         required: ['docType', 'documentId'],

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -240,6 +240,10 @@ export function getDocumentTools(client: HoldedClient) {
             type: 'string',
             description: 'Sales channel ID to associate with the document',
           },
+          expAccountId: {
+            type: 'string',
+            description: 'Expense account ID to associate with the expense document',
+          },
         },
         required: ['docType', 'contactId', 'items'],
       },
@@ -336,6 +340,10 @@ export function getDocumentTools(client: HoldedClient) {
           salesChannelId: {
             type: 'string',
             description: 'Sales channel ID to associate with the document',
+          },
+          expAccountId: {
+            type: 'string',
+            description: 'Expense account ID to associate with the expense document',
           },
         },
         required: ['docType', 'documentId'],

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -209,7 +209,8 @@ export function getDocumentTools(client: HoldedClient) {
           },
           items: {
             type: 'array',
-            description: 'Array of line items',
+            description:
+              'Array of line items. Each line requires name, units and subtotal. taxes, if present, must contain exactly one Holded tax ID.',
             items: {
               type: 'object',
               properties: {
@@ -217,7 +218,15 @@ export function getDocumentTools(client: HoldedClient) {
                 units: { type: 'number' },
                 subtotal: { type: 'number' },
                 tax: { type: 'number' },
+                taxes: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  minItems: 1,
+                  maxItems: 1,
+                  description: 'Single Holded tax ID to apply to this line item',
+                },
               },
+              required: ['name', 'units', 'subtotal'],
             },
           },
           date: {
@@ -323,7 +332,25 @@ export function getDocumentTools(client: HoldedClient) {
           },
           items: {
             type: 'array',
-            description: 'Array of line items',
+            description:
+              'Array of line items. Each line requires name, units and subtotal. taxes, if present, must contain exactly one Holded tax ID.',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                units: { type: 'number' },
+                subtotal: { type: 'number' },
+                tax: { type: 'number' },
+                taxes: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  minItems: 1,
+                  maxItems: 1,
+                  description: 'Single Holded tax ID to apply to this line item',
+                },
+              },
+              required: ['name', 'units', 'subtotal'],
+            },
           },
           date: {
             type: 'number',

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -188,7 +188,7 @@ export const createDocumentSchema = z.object({
   ]),
   contactId: z.string().min(1),
   items: z.array(z.unknown()),
-  date: z.string().optional(),
+  date: z.number().optional(),
   notes: z.string().optional(),
   currency: z.string().optional(),
 });
@@ -197,7 +197,7 @@ export const updateDocumentSchema = documentIdSchema.merge(
   z.object({
     contactId: z.string().optional(),
     items: z.array(z.unknown()).optional(),
-    date: z.string().optional(),
+    date: z.number().optional(),
     notes: z.string().optional(),
     currency: z.string().optional(),
   })

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -193,6 +193,7 @@ export const createDocumentSchema = z.object({
   currency: z.string().optional(),
   invoiceNum: z.string().optional(),
   salesChannelId: z.string().optional(),
+  expAccountId: z.string().optional(),
 });
 
 export const updateDocumentSchema = documentIdSchema.merge(
@@ -204,6 +205,7 @@ export const updateDocumentSchema = documentIdSchema.merge(
     currency: z.string().optional(),
     invoiceNum: z.string().optional(),
     salesChannelId: z.string().optional(),
+    expAccountId: z.string().optional(),
   })
 );
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -202,6 +202,7 @@ export const updateDocumentSchema = documentIdSchema.merge(
     date: z.number().optional(),
     notes: z.string().optional(),
     currency: z.string().optional(),
+    invoiceNum: z.string().optional(),
     salesChannelId: z.string().optional(),
   })
 );

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -191,6 +191,7 @@ export const createDocumentSchema = z.object({
   date: z.number().optional(),
   notes: z.string().optional(),
   currency: z.string().optional(),
+  invoiceNum: z.string().optional(),
 });
 
 export const updateDocumentSchema = documentIdSchema.merge(
@@ -200,6 +201,7 @@ export const updateDocumentSchema = documentIdSchema.merge(
     date: z.number().optional(),
     notes: z.string().optional(),
     currency: z.string().optional(),
+    invoiceNum: z.string().optional(),
   })
 );
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -201,7 +201,6 @@ export const updateDocumentSchema = documentIdSchema.merge(
     date: z.number().optional(),
     notes: z.string().optional(),
     currency: z.string().optional(),
-    invoiceNum: z.string().optional(),
   })
 );
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -176,6 +176,16 @@ export const updateDocumentTrackingSchema = z.object({
   carrier: z.string().optional(),
 });
 
+const documentItemSchema = z
+  .object({
+    name: z.string().min(1),
+    units: z.number(),
+    subtotal: z.number(),
+    tax: z.number().optional(),
+    taxes: z.array(z.string()).length(1).optional(),
+  })
+  .passthrough();
+
 export const createDocumentSchema = z.object({
   docType: z.enum([
     'invoice',
@@ -187,7 +197,7 @@ export const createDocumentSchema = z.object({
     'purchase',
   ]),
   contactId: z.string().min(1),
-  items: z.array(z.unknown()),
+  items: z.array(documentItemSchema),
   date: z.number().optional(),
   notes: z.string().optional(),
   currency: z.string().optional(),
@@ -199,7 +209,7 @@ export const createDocumentSchema = z.object({
 export const updateDocumentSchema = documentIdSchema.merge(
   z.object({
     contactId: z.string().optional(),
-    items: z.array(z.unknown()).optional(),
+    items: z.array(documentItemSchema).optional(),
     date: z.number().optional(),
     notes: z.string().optional(),
     currency: z.string().optional(),

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -192,6 +192,7 @@ export const createDocumentSchema = z.object({
   notes: z.string().optional(),
   currency: z.string().optional(),
   invoiceNum: z.string().optional(),
+  salesChannelId: z.string().optional(),
 });
 
 export const updateDocumentSchema = documentIdSchema.merge(
@@ -201,6 +202,7 @@ export const updateDocumentSchema = documentIdSchema.merge(
     date: z.number().optional(),
     notes: z.string().optional(),
     currency: z.string().optional(),
+    salesChannelId: z.string().optional(),
   })
 );
 


### PR DESCRIPTION
This PR fixes date format for documents since it should be an integer instead of string. Whitout this fix, documents cannot be created. 

Also, invoiceNum field has been added for new documents. This field doesn't exist on updateDocuments Holded API  endpoint.