### PR TITLE
fix: resolve document date, contact vatnumber, and contactPersons issues

### DIFF
--- a/src/__tests__/contacts.test.ts
+++ b/src/__tests__/contacts.test.ts
@@ -85,16 +85,30 @@ describe('Contact Tools', () => {
       expect(client.post).toHaveBeenCalledWith('/contacts', { name: 'Test Contact' });
     });
 
-    it('should include optional fields', async () => {
+    it('should include optional fields including code (NIF/CIF/VAT)', async () => {
       const args = {
         name: 'Test Contact',
         email: 'test@example.com',
         phone: '+34600000000',
-        vatnumber: 'B12345678',
-        type: 'client',
+        code: 'B12345678',
+        type: 'client' as const,
       };
       await tools.create_contact.handler(args);
       expect(client.post).toHaveBeenCalledWith('/contacts', args);
+    });
+
+    it('should use code field for NIF/CIF/VAT (not vatnumber)', async () => {
+      // The Holded API uses 'code' for NIF/CIF/VAT — 'vatnumber' does not exist
+      const args = {
+        name: 'Empresa SL',
+        code: 'B98765432',
+      };
+      await tools.create_contact.handler(args);
+      expect(client.post).toHaveBeenCalledWith('/contacts', args);
+      // Verify 'vatnumber' key is NOT present in what's sent to the API
+      const callArgs = (client.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(callArgs).not.toHaveProperty('vatnumber');
+      expect(callArgs).toHaveProperty('code', 'B98765432');
     });
 
     it('should include billing address', async () => {
@@ -107,6 +121,57 @@ describe('Contact Tools', () => {
           country: 'ES',
         },
       };
+      await tools.create_contact.handler(args);
+      expect(client.post).toHaveBeenCalledWith('/contacts', args);
+    });
+
+    it('should include contactPersons when provided', async () => {
+      const args = {
+        name: 'Empresa SL',
+        contactPersons: [
+          { name: 'Ana García', phone: '+34600000001', email: 'ana@empresa.com' },
+          { name: 'Luis Pérez' },
+        ],
+      };
+      await tools.create_contact.handler(args);
+      expect(client.post).toHaveBeenCalledWith('/contacts', args);
+    });
+
+    it('should reject contactPersons entries missing required name', async () => {
+      await expect(
+        tools.create_contact.handler({
+          name: 'Empresa SL',
+          contactPersons: [{ phone: '+34600000001' } as any],
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should reject invalid email format in contactPersons', async () => {
+      await expect(
+        tools.create_contact.handler({
+          name: 'Empresa SL',
+          contactPersons: [{ name: 'Ana García', email: 'not-a-valid-email' }],
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should accept valid email format in contactPersons', async () => {
+      const args = {
+        name: 'Empresa SL',
+        contactPersons: [{ name: 'Ana García', email: 'ana@empresa.com' }],
+      };
+      await tools.create_contact.handler(args);
+      expect(client.post).toHaveBeenCalledWith('/contacts', args);
+    });
+
+    it('contactPersons email field should have format: email in inputSchema', () => {
+      const contactPersonsItems = (tools.create_contact.inputSchema.properties as any)
+        .contactPersons.items;
+      expect(contactPersonsItems.properties.email.format).toBe('email');
+    });
+
+    it('should create contact without contactPersons (field is optional)', async () => {
+      const args = { name: 'Solo Contact', email: 'solo@example.com' };
       await tools.create_contact.handler(args);
       expect(client.post).toHaveBeenCalledWith('/contacts', args);
     });
@@ -130,6 +195,28 @@ describe('Contact Tools', () => {
       expect(client.put).toHaveBeenCalledWith('/contacts/contact-123', {
         name: 'Updated Name',
         email: 'updated@example.com',
+      });
+    });
+
+    it('should update the code field (NIF/CIF/VAT) correctly', async () => {
+      const args = {
+        contactId: 'contact-123',
+        code: 'A12345678',
+      };
+      await tools.update_contact.handler(args);
+      expect(client.put).toHaveBeenCalledWith('/contacts/contact-123', {
+        code: 'A12345678',
+      });
+    });
+
+    it('should update contactPersons', async () => {
+      const args = {
+        contactId: 'contact-123',
+        contactPersons: [{ name: 'Maria López', email: 'maria@empresa.com' }],
+      };
+      await tools.update_contact.handler(args);
+      expect(client.put).toHaveBeenCalledWith('/contacts/contact-123', {
+        contactPersons: [{ name: 'Maria López', email: 'maria@empresa.com' }],
       });
     });
   });

--- a/src/__tests__/documents.test.ts
+++ b/src/__tests__/documents.test.ts
@@ -79,24 +79,48 @@ describe('Document Tools', () => {
   });
 
   describe('create_document', () => {
-    it('should create a document with required fields', async () => {
+    it('should create a document with required fields including date as Unix timestamp', async () => {
       const args = {
         docType: 'invoice' as const,
         contactId: 'contact-123',
         items: [{ name: 'Item 1', units: 1, subtotal: 100 }],
+        date: 1700000000,
       };
       await tools.create_document.handler(args);
       expect(client.post).toHaveBeenCalledWith('/documents/invoice', {
         contactId: 'contact-123',
         items: [{ name: 'Item 1', units: 1, subtotal: 100 }],
+        date: 1700000000,
       });
     });
 
-    it('should include optional fields', async () => {
+    it('should reject date as string (must be Unix timestamp integer)', async () => {
+      await expect(
+        tools.create_document.handler({
+          docType: 'invoice' as const,
+          contactId: 'contact-123',
+          items: [],
+          date: '2024-01-15' as any,
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should reject missing date field', async () => {
+      await expect(
+        tools.create_document.handler({
+          docType: 'invoice' as const,
+          contactId: 'contact-123',
+          items: [],
+        } as any)
+      ).rejects.toThrow();
+    });
+
+    it('should include optional fields alongside required date', async () => {
       const args = {
         docType: 'invoice' as const,
         contactId: 'contact-123',
         items: [],
+        date: 1700000000,
         notes: 'Test notes',
         currency: 'EUR',
       };
@@ -104,9 +128,49 @@ describe('Document Tools', () => {
       expect(client.post).toHaveBeenCalledWith('/documents/invoice', {
         contactId: 'contact-123',
         items: [],
+        date: 1700000000,
         notes: 'Test notes',
         currency: 'EUR',
       });
+    });
+
+    it('should accept date as current Unix timestamp', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const args = {
+        docType: 'estimate' as const,
+        contactId: 'contact-456',
+        items: [{ name: 'Service', units: 1, subtotal: 200 }],
+        date: now,
+      };
+      await tools.create_document.handler(args);
+      expect(client.post).toHaveBeenCalledWith('/documents/estimate', {
+        contactId: 'contact-456',
+        items: [{ name: 'Service', units: 1, subtotal: 200 }],
+        date: now,
+      });
+    });
+
+    it('should accept extended docTypes: salesreceipt, creditnote, receiptnote, purchaserefund', async () => {
+      const extendedTypes = [
+        'salesreceipt',
+        'creditnote',
+        'receiptnote',
+        'purchaserefund',
+      ] as const;
+      for (const docType of extendedTypes) {
+        const args = {
+          docType,
+          contactId: 'contact-123',
+          items: [],
+          date: 1700000000,
+        };
+        await tools.create_document.handler(args);
+        expect(client.post).toHaveBeenCalledWith(`/documents/${docType}`, {
+          contactId: 'contact-123',
+          items: [],
+          date: 1700000000,
+        });
+      }
     });
   });
 
@@ -128,6 +192,46 @@ describe('Document Tools', () => {
       expect(client.put).toHaveBeenCalledWith('/documents/invoice/doc-123', {
         notes: 'Updated notes',
       });
+    });
+
+    it('should accept date as Unix timestamp integer when updating', async () => {
+      const args = {
+        docType: 'invoice' as const,
+        documentId: 'doc-123',
+        date: 1700086400,
+        notes: 'Revised notes',
+      };
+      await tools.update_document.handler(args);
+      expect(client.put).toHaveBeenCalledWith('/documents/invoice/doc-123', {
+        date: 1700086400,
+        notes: 'Revised notes',
+      });
+    });
+
+    it('should reject date as string when updating', async () => {
+      await expect(
+        tools.update_document.handler({
+          docType: 'invoice' as const,
+          documentId: 'doc-123',
+          date: '2024-01-15' as any,
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should accept currency field when updating a document', async () => {
+      const args = {
+        docType: 'invoice' as const,
+        documentId: 'doc-123',
+        currency: 'USD',
+      };
+      await tools.update_document.handler(args);
+      expect(client.put).toHaveBeenCalledWith('/documents/invoice/doc-123', {
+        currency: 'USD',
+      });
+    });
+
+    it('inputSchema should include currency field in update_document', () => {
+      expect(tools.update_document.inputSchema.properties).toHaveProperty('currency');
     });
   });
 
@@ -169,6 +273,46 @@ describe('Document Tools', () => {
         subject: 'Invoice',
         message: 'Please find attached',
       });
+    });
+
+    it('should send a document without emails (emails is optional)', async () => {
+      // emails is optional — the document can be sent to the contact associated with it
+      const args = {
+        docType: 'invoice' as const,
+        documentId: 'doc-123',
+        subject: 'Invoice',
+        message: 'Please find attached',
+      };
+      await tools.send_document.handler(args);
+      expect(client.post).toHaveBeenCalledWith('/documents/invoice/doc-123/send', {
+        subject: 'Invoice',
+        message: 'Please find attached',
+      });
+    });
+
+    it('should send a document with only required fields (docType and documentId)', async () => {
+      const args = {
+        docType: 'invoice' as const,
+        documentId: 'doc-123',
+      };
+      await tools.send_document.handler(args);
+      expect(client.post).toHaveBeenCalledWith('/documents/invoice/doc-123/send', {});
+    });
+
+    it('should reject invalid email addresses in emails array', async () => {
+      await expect(
+        tools.send_document.handler({
+          docType: 'invoice' as const,
+          documentId: 'doc-123',
+          emails: ['not-an-email'],
+        })
+      ).rejects.toThrow();
+    });
+
+    it('inputSchema should not include emails in required array', () => {
+      expect(tools.send_document.inputSchema.required).not.toContain('emails');
+      expect(tools.send_document.inputSchema.required).toContain('docType');
+      expect(tools.send_document.inputSchema.required).toContain('documentId');
     });
   });
 

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -135,9 +135,10 @@ export function getContactTools(client: HoldedClient) {
             type: 'string',
             description: 'Contact phone number',
           },
-          vatnumber: {
+          code: {
             type: 'string',
-            description: 'VAT number / Tax ID',
+            description:
+              'NIF / CIF / VAT number or tax identification code for the contact. This is the correct Holded API field for tax IDs. Note: the legacy "vatnumber" field does not exist in Holded and is silently ignored.',
           },
           type: {
             type: 'string',
@@ -159,13 +160,32 @@ export function getContactTools(client: HoldedClient) {
             type: 'string',
             description: 'Trade name',
           },
-          code: {
-            type: 'string',
-            description: 'Contact code',
-          },
           note: {
             type: 'string',
             description: 'Notes about the contact',
+          },
+          contactPersons: {
+            type: 'array',
+            description: 'List of contact persons associated with this contact',
+            items: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                  description: 'Contact person name (required)',
+                },
+                phone: {
+                  type: 'string',
+                  description: 'Contact person phone number',
+                },
+                email: {
+                  type: 'string',
+                  format: 'email',
+                  description: 'Contact person email address',
+                },
+              },
+              required: ['name'],
+            },
           },
         },
         required: ['name'],
@@ -217,9 +237,10 @@ export function getContactTools(client: HoldedClient) {
             type: 'string',
             description: 'Contact phone number',
           },
-          vatnumber: {
+          code: {
             type: 'string',
-            description: 'VAT number / Tax ID',
+            description:
+              'NIF / CIF / VAT number or tax identification code for the contact. This is the correct Holded API field for tax IDs. Note: the legacy "vatnumber" field does not exist in Holded and is silently ignored.',
           },
           type: {
             type: 'string',
@@ -229,6 +250,44 @@ export function getContactTools(client: HoldedClient) {
           billAddress: {
             type: 'object',
             description: 'Billing address',
+            properties: {
+              address: { type: 'string' },
+              city: { type: 'string' },
+              postalCode: { type: 'string' },
+              province: { type: 'string' },
+              country: { type: 'string' },
+            },
+          },
+          tradename: {
+            type: 'string',
+            description: 'Trade name',
+          },
+          note: {
+            type: 'string',
+            description: 'Notes about the contact',
+          },
+          contactPersons: {
+            type: 'array',
+            description: 'List of contact persons associated with this contact',
+            items: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                  description: 'Contact person name (required)',
+                },
+                phone: {
+                  type: 'string',
+                  description: 'Contact person phone number',
+                },
+                email: {
+                  type: 'string',
+                  format: 'email',
+                  description: 'Contact person email address',
+                },
+              },
+              required: ['name'],
+            },
           },
         },
         required: ['contactId'],

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -233,7 +233,7 @@ export function getDocumentTools(client: HoldedClient) {
             description: 'Currency code (e.g., EUR, USD)',
           },
         },
-        required: ['docType', 'contactId', 'items'],
+        required: ['docType', 'contactId', 'items', 'date'],
       },
       destructiveHint: true,
       handler: withValidation(createDocumentSchema, async (args) => {
@@ -320,6 +320,10 @@ export function getDocumentTools(client: HoldedClient) {
           notes: {
             type: 'string',
             description: 'Notes for the document',
+          },
+          currency: {
+            type: 'string',
+            description: 'Currency code (e.g., EUR, USD)',
           },
         },
         required: ['docType', 'documentId'],
@@ -457,7 +461,7 @@ export function getDocumentTools(client: HoldedClient) {
             description: 'Email message body',
           },
         },
-        required: ['docType', 'documentId', 'emails'],
+        required: ['docType', 'documentId'],
       },
       destructiveHint: true,
       handler: withValidation(sendDocumentSchema, async (args) => {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -28,11 +28,22 @@ export const contactIdSchema = z.object({
   contactId: z.string().min(1),
 });
 
+export const contactPersonSchema = z.object({
+  name: z.string().min(1),
+  phone: z.string().optional(),
+  email: z.string().email().optional(),
+});
+
 export const createContactSchema = z.object({
   name: z.string().min(1),
   email: z.string().email().optional(),
   phone: z.string().optional(),
-  vatnumber: z.string().optional(),
+  /**
+   * NIF/CIF/VAT identifier for the contact. This is the correct Holded API field
+   * for tax identification numbers. The legacy `vatnumber` field does not exist in
+   * the Holded API and is silently ignored — use `code` instead.
+   */
+  code: z.string().optional(),
   type: z.enum(['client', 'supplier', 'lead', 'debtor', 'creditor']).optional(),
   billAddress: z
     .object({
@@ -44,8 +55,12 @@ export const createContactSchema = z.object({
     })
     .optional(),
   tradename: z.string().optional(),
-  code: z.string().optional(),
   note: z.string().optional(),
+  /**
+   * List of contact persons associated with this contact.
+   * Each person requires a name; phone and email are optional.
+   */
+  contactPersons: z.array(contactPersonSchema).optional(),
 });
 
 export const updateContactSchema = contactIdSchema.merge(createContactSchema.partial());
@@ -179,16 +194,25 @@ export const updateDocumentTrackingSchema = z.object({
 export const createDocumentSchema = z.object({
   docType: z.enum([
     'invoice',
+    'salesreceipt',
+    'creditnote',
+    'receiptnote',
     'estimate',
     'salesorder',
-    'purchaseorder',
     'waybill',
     'proform',
     'purchase',
+    'purchaserefund',
+    'purchaseorder',
   ]),
   contactId: z.string().min(1),
   items: z.array(z.unknown()),
-  date: z.string().optional(),
+  /**
+   * Document date as Unix timestamp (integer). Required by the Holded API.
+   * If omitted, Holded will reject the request. Use Math.floor(Date.now() / 1000)
+   * to get the current timestamp.
+   */
+  date: z.number().int(),
   notes: z.string().optional(),
   currency: z.string().optional(),
 });
@@ -197,7 +221,11 @@ export const updateDocumentSchema = documentIdSchema.merge(
   z.object({
     contactId: z.string().optional(),
     items: z.array(z.unknown()).optional(),
-    date: z.string().optional(),
+    /**
+     * Document date as Unix timestamp (integer).
+     * Required by the Holded API when updating the date field.
+     */
+    date: z.number().int().optional(),
     notes: z.string().optional(),
     currency: z.string().optional(),
   })


### PR DESCRIPTION
## Summary
Fixes 3 bugs reported in #36 plus additional schema inconsistencies found during code review.

- **Bug 1 (critical):** `create_document` date field typed as `z.string()` but Holded API expects integer Unix timestamp — changed to `z.number().int()` and made required
- **Bug 2:** `vatnumber` field silently ignored by Holded API — replaced with `code` (correct field for NIF/CIF/VAT)
- **Bug 3:** `contactPersons` not exposed in contact tools — added to both create and update schemas
- **Review fix:** `send_document` emails marked required in inputSchema but optional in Zod — aligned as optional
- **Review fix:** Added `.email()` validation to `contactPersonSchema.email`
- **Review fix:** Aligned `docType` enum between Zod and inputSchema (added `salesreceipt`, `creditnote`, `receiptnote`, `purchaserefund`)
- **Review fix:** Added `currency` to `update_document` inputSchema

## Test plan
- [x] All 160 tests pass
- [x] Verified date field rejects strings and accepts Unix timestamps
- [x] Verified `code` field replaces `vatnumber` in API calls
- [x] Verified `contactPersons` accepted in create/update with name validation
- [x] Verified `send_document` works without emails
- [x] Verified extended docType enum accepted in Zod validation

Closes #36