### PR TITLE
feat: add document item validation, invoiceNum, taxes, and shared docTypeEnum

### DIFF
--- a/src/__tests__/documents.test.ts
+++ b/src/__tests__/documents.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createMockClient } from './mock-client.js';
 import { getDocumentTools } from '../tools/documents.js';
+import {
+  documentItemSchema,
+  docTypeEnum,
+  documentIdSchema,
+  listDocumentsSchema,
+  updateDocumentPipelineSchema,
+  attachFileToDocumentSchema,
+  shipItemsByLineSchema,
+  payDocumentSchema,
+  sendDocumentSchema,
+  updateDocumentTrackingSchema,
+  createDocumentSchema,
+  updateDocumentSchema,
+  numberingSerieIdSchema,
+  createNumberingSerieSchema,
+} from '../validation.js';
 
 describe('Document Tools', () => {
   let client: ReturnType<typeof createMockClient>;
@@ -404,6 +420,477 @@ describe('Document Tools', () => {
     it('should list payment methods', async () => {
       await tools.list_payment_methods.handler();
       expect(client.get).toHaveBeenCalledWith('/paymentmethods');
+    });
+  });
+
+  describe('invoiceNum field', () => {
+    it('should include invoiceNum in create_document inputSchema', () => {
+      expect(tools.create_document.inputSchema.properties).toHaveProperty('invoiceNum');
+    });
+
+    it('should include invoiceNum in update_document inputSchema', () => {
+      expect(tools.update_document.inputSchema.properties).toHaveProperty('invoiceNum');
+    });
+
+    it('should pass invoiceNum to the API on create', async () => {
+      await tools.create_document.handler({
+        docType: 'purchase' as const,
+        contactId: 'contact-123',
+        items: [{ name: 'Part A', units: 2, subtotal: 50 }],
+        date: 1700000000,
+        invoiceNum: 'PROV-2024-001',
+      });
+      expect(client.post).toHaveBeenCalledWith('/documents/purchase', {
+        contactId: 'contact-123',
+        items: [{ name: 'Part A', units: 2, subtotal: 50 }],
+        date: 1700000000,
+        invoiceNum: 'PROV-2024-001',
+      });
+    });
+
+    it('should pass invoiceNum to the API on update', async () => {
+      await tools.update_document.handler({
+        docType: 'invoice' as const,
+        documentId: 'doc-123',
+        invoiceNum: 'INV-2024-007',
+      });
+      expect(client.put).toHaveBeenCalledWith('/documents/invoice/doc-123', {
+        invoiceNum: 'INV-2024-007',
+      });
+    });
+
+    it('should not require invoiceNum (optional field)', async () => {
+      const args = {
+        docType: 'invoice' as const,
+        contactId: 'contact-123',
+        items: [],
+        date: 1700000000,
+      };
+      await expect(tools.create_document.handler(args)).resolves.not.toThrow();
+    });
+  });
+
+  describe('taxes array per line item', () => {
+    it('documentItemSchema should accept taxes array with exactly 1 element', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'Service X',
+        units: 1,
+        subtotal: 100,
+        taxes: ['tax-id-holded'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('documentItemSchema should reject taxes array with more than 1 element', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'Service X',
+        units: 1,
+        subtotal: 100,
+        taxes: ['tax-id-1', 'tax-id-2'],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('documentItemSchema should accept taxes as undefined (optional)', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'Service X',
+        units: 1,
+        subtotal: 100,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('documentItemSchema should accept both tax (number) and taxes (array) simultaneously for backward compatibility', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'Service X',
+        units: 1,
+        subtotal: 100,
+        tax: 21,
+        taxes: ['holded-tax-id'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('create_document inputSchema should include taxes with maxItems: 1 on line items', () => {
+      const itemsSchema = (tools.create_document.inputSchema.properties as any).items;
+      expect(itemsSchema.items.properties.taxes.maxItems).toBe(1);
+      expect(itemsSchema.items.properties.taxes.minItems).toBe(1);
+    });
+
+    it('update_document inputSchema should include taxes with maxItems: 1 on line items', () => {
+      const itemsSchema = (tools.update_document.inputSchema.properties as any).items;
+      expect(itemsSchema.items.properties.taxes.maxItems).toBe(1);
+    });
+
+    it('should pass taxes array in line items to the API on create', async () => {
+      await tools.create_document.handler({
+        docType: 'invoice' as const,
+        contactId: 'contact-123',
+        items: [{ name: 'Service A', units: 1, subtotal: 200, taxes: ['holded-tax-123'] }],
+        date: 1700000000,
+      });
+      expect(client.post).toHaveBeenCalledWith('/documents/invoice', {
+        contactId: 'contact-123',
+        items: [{ name: 'Service A', units: 1, subtotal: 200, taxes: ['holded-tax-123'] }],
+        date: 1700000000,
+      });
+    });
+  });
+
+  describe('salesChannelId field', () => {
+    it('should include salesChannelId in create_document inputSchema', () => {
+      expect(tools.create_document.inputSchema.properties).toHaveProperty('salesChannelId');
+    });
+
+    it('should include salesChannelId in update_document inputSchema', () => {
+      expect(tools.update_document.inputSchema.properties).toHaveProperty('salesChannelId');
+    });
+
+    it('should pass salesChannelId to the API on create', async () => {
+      await tools.create_document.handler({
+        docType: 'invoice' as const,
+        contactId: 'contact-123',
+        items: [{ name: 'Item', units: 1, subtotal: 100 }],
+        date: 1700000000,
+        salesChannelId: 'channel-abc',
+      });
+      expect(client.post).toHaveBeenCalledWith('/documents/invoice', {
+        contactId: 'contact-123',
+        items: [{ name: 'Item', units: 1, subtotal: 100 }],
+        date: 1700000000,
+        salesChannelId: 'channel-abc',
+      });
+    });
+
+    it('should pass salesChannelId to the API on update', async () => {
+      await tools.update_document.handler({
+        docType: 'invoice' as const,
+        documentId: 'doc-123',
+        salesChannelId: 'channel-xyz',
+      });
+      expect(client.put).toHaveBeenCalledWith('/documents/invoice/doc-123', {
+        salesChannelId: 'channel-xyz',
+      });
+    });
+  });
+
+  describe('expAccountId field', () => {
+    it('should include expAccountId in create_document inputSchema', () => {
+      expect(tools.create_document.inputSchema.properties).toHaveProperty('expAccountId');
+    });
+
+    it('should include expAccountId in update_document inputSchema', () => {
+      expect(tools.update_document.inputSchema.properties).toHaveProperty('expAccountId');
+    });
+
+    it('should pass expAccountId to the API on create', async () => {
+      await tools.create_document.handler({
+        docType: 'purchase' as const,
+        contactId: 'contact-123',
+        items: [{ name: 'Office Supply', units: 1, subtotal: 50 }],
+        date: 1700000000,
+        expAccountId: 'exp-account-456',
+      });
+      expect(client.post).toHaveBeenCalledWith('/documents/purchase', {
+        contactId: 'contact-123',
+        items: [{ name: 'Office Supply', units: 1, subtotal: 50 }],
+        date: 1700000000,
+        expAccountId: 'exp-account-456',
+      });
+    });
+
+    it('should pass expAccountId to the API on update', async () => {
+      await tools.update_document.handler({
+        docType: 'purchase' as const,
+        documentId: 'doc-456',
+        expAccountId: 'exp-account-789',
+      });
+      expect(client.put).toHaveBeenCalledWith('/documents/purchase/doc-456', {
+        expAccountId: 'exp-account-789',
+      });
+    });
+  });
+
+  describe('documentItemSchema validation', () => {
+    it('should require name, units, and subtotal', () => {
+      const result = documentItemSchema.safeParse({ name: 'A', units: 1, subtotal: 100 });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject item missing name', () => {
+      const result = documentItemSchema.safeParse({ units: 1, subtotal: 100 });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject item missing units', () => {
+      const result = documentItemSchema.safeParse({ name: 'A', subtotal: 100 });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject item missing subtotal', () => {
+      const result = documentItemSchema.safeParse({ name: 'A', units: 1 });
+      expect(result.success).toBe(false);
+    });
+
+    it('should accept all optional fields', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'Product',
+        units: 3,
+        subtotal: 300,
+        desc: 'A detailed description',
+        sku: 'SKU-001',
+        tax: 21,
+        taxes: ['holded-tax-id'],
+        discount: 10,
+        serviceId: 'service-abc',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should pass through unknown fields (passthrough)', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'X',
+        units: 1,
+        subtotal: 10,
+        unknownApiField: 'some-value',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect((result.data as any).unknownApiField).toBe('some-value');
+      }
+    });
+
+    it('should reject tax value above 100', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'X',
+        units: 1,
+        subtotal: 10,
+        tax: 150,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject discount value above 100', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'X',
+        units: 1,
+        subtotal: 10,
+        discount: 110,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject taxes array with more than 1 element', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'X',
+        units: 1,
+        subtotal: 10,
+        taxes: ['id-1', 'id-2'],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('create_document should reject items with missing required line item fields', async () => {
+      await expect(
+        tools.create_document.handler({
+          docType: 'invoice' as const,
+          contactId: 'contact-123',
+          items: [{ units: 1, subtotal: 100 } as any],
+          date: 1700000000,
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('update_document item validation', () => {
+    it('should reject items without name when updating a document', async () => {
+      await expect(
+        tools.update_document.handler({
+          docType: 'invoice' as const,
+          documentId: 'doc-123',
+          items: [{ units: 2, subtotal: 100 } as any],
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should reject items without units when updating a document', async () => {
+      await expect(
+        tools.update_document.handler({
+          docType: 'invoice' as const,
+          documentId: 'doc-123',
+          items: [{ name: 'Service A', subtotal: 100 } as any],
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should reject items without subtotal when updating a document', async () => {
+      await expect(
+        tools.update_document.handler({
+          docType: 'invoice' as const,
+          documentId: 'doc-123',
+          items: [{ name: 'Service A', units: 1 } as any],
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should accept valid items when updating a document', async () => {
+      await expect(
+        tools.update_document.handler({
+          docType: 'invoice' as const,
+          documentId: 'doc-123',
+          items: [{ name: 'Service A', units: 1, subtotal: 100 }],
+        })
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('docTypeEnum consistency — regression prevention', () => {
+    /**
+     * This test ensures that ALL document-related schemas reference the same
+     * shared docTypeEnum constant, preventing future regressions where a new
+     * document type is added to some schemas but not others.
+     *
+     * The test works by verifying that each schema accepts every value from
+     * docTypeEnum.options — if any schema uses a narrower enum, this will fail.
+     */
+    const ALL_DOC_TYPES = docTypeEnum.options;
+
+    const schemasWithDocType: Array<{ name: string; parse: (docType: string) => unknown }> = [
+      {
+        name: 'documentIdSchema',
+        parse: (docType) => documentIdSchema.safeParse({ docType, documentId: 'id-1' }),
+      },
+      {
+        name: 'listDocumentsSchema',
+        parse: (docType) => listDocumentsSchema.safeParse({ docType }),
+      },
+      {
+        name: 'updateDocumentPipelineSchema',
+        parse: (docType) =>
+          updateDocumentPipelineSchema.safeParse({
+            docType,
+            documentId: 'id-1',
+            pipelineId: 'pipe-1',
+            stageId: 'stage-1',
+          }),
+      },
+      {
+        name: 'attachFileToDocumentSchema',
+        parse: (docType) =>
+          attachFileToDocumentSchema.safeParse({
+            docType,
+            documentId: 'id-1',
+            fileBase64: 'abc',
+            filename: 'test.pdf',
+          }),
+      },
+      {
+        name: 'shipItemsByLineSchema',
+        parse: (docType) =>
+          shipItemsByLineSchema.safeParse({ docType, documentId: 'id-1', lines: [] }),
+      },
+      {
+        name: 'payDocumentSchema',
+        parse: (docType) => payDocumentSchema.safeParse({ docType, documentId: 'id-1' }),
+      },
+      {
+        name: 'sendDocumentSchema',
+        parse: (docType) => sendDocumentSchema.safeParse({ docType, documentId: 'id-1' }),
+      },
+      {
+        name: 'updateDocumentTrackingSchema',
+        parse: (docType) => updateDocumentTrackingSchema.safeParse({ docType, documentId: 'id-1' }),
+      },
+      {
+        name: 'createDocumentSchema',
+        parse: (docType) =>
+          createDocumentSchema.safeParse({
+            docType,
+            contactId: 'contact-1',
+            items: [],
+            date: 1700000000,
+          }),
+      },
+      {
+        name: 'updateDocumentSchema',
+        parse: (docType) => updateDocumentSchema.safeParse({ docType, documentId: 'id-1' }),
+      },
+      {
+        name: 'numberingSerieIdSchema',
+        parse: (docType) => numberingSerieIdSchema.safeParse({ docType, serieId: 'serie-1' }),
+      },
+      {
+        name: 'createNumberingSerieSchema',
+        parse: (docType) => createNumberingSerieSchema.safeParse({ docType, name: 'Serie A' }),
+      },
+    ];
+
+    for (const schema of schemasWithDocType) {
+      it(`${schema.name} should accept all docTypeEnum values`, () => {
+        for (const docType of ALL_DOC_TYPES) {
+          const result = schema.parse(docType) as { success: boolean };
+          expect(result.success, `${schema.name} rejected docType "${docType}"`).toBe(true);
+        }
+      });
+    }
+
+    it('should reject unknown docType in all schemas', () => {
+      for (const schema of schemasWithDocType) {
+        const result = schema.parse('unknowntype') as { success: boolean };
+        expect(result.success, `${schema.name} unexpectedly accepted "unknowntype"`).toBe(false);
+      }
+    });
+  });
+
+  describe('payDocumentSchema.date integer validation', () => {
+    it('should accept integer Unix timestamp for payment date', () => {
+      const result = payDocumentSchema.safeParse({
+        docType: 'invoice',
+        documentId: 'doc-123',
+        date: 1700000000,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject float (non-integer) payment date', () => {
+      const result = payDocumentSchema.safeParse({
+        docType: 'invoice',
+        documentId: 'doc-123',
+        date: 1700000000.5,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('documentItemSchema taxes empty array rejection', () => {
+    it('should reject taxes as empty array (min 1 required when provided)', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'Service X',
+        units: 1,
+        subtotal: 100,
+        taxes: [],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should accept taxes with exactly 1 element', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'Service X',
+        units: 1,
+        subtotal: 100,
+        taxes: ['holded-tax-id'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject taxes with more than 1 element', () => {
+      const result = documentItemSchema.safeParse({
+        name: 'Service X',
+        units: 1,
+        subtotal: 100,
+        taxes: ['tax-1', 'tax-2'],
+      });
+      expect(result.success).toBe(false);
     });
   });
 

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -213,11 +213,33 @@ export function getDocumentTools(client: HoldedClient) {
             items: {
               type: 'object',
               properties: {
-                name: { type: 'string' },
-                units: { type: 'number' },
-                subtotal: { type: 'number' },
-                tax: { type: 'number' },
+                name: { type: 'string', description: 'Product or service name' },
+                units: { type: 'number', description: 'Quantity of units' },
+                subtotal: {
+                  type: 'number',
+                  description: 'Line subtotal (price × units before tax/discount)',
+                },
+                desc: { type: 'string', description: 'Optional line description' },
+                sku: { type: 'string', description: 'SKU / product reference code' },
+                tax: {
+                  type: 'number',
+                  description: 'Tax percentage (0–100) — alternative to taxes array',
+                },
+                taxes: {
+                  type: 'array',
+                  description:
+                    'Holded tax ID(s) for the line item (max 1 element). Use instead of tax when referencing a specific Holded tax definition.',
+                  items: { type: 'string' },
+                  minItems: 1,
+                  maxItems: 1,
+                },
+                discount: { type: 'number', description: 'Discount percentage (0–100)' },
+                serviceId: {
+                  type: 'string',
+                  description: 'Service ID to link to a Holded service catalog entry',
+                },
               },
+              required: ['name', 'units', 'subtotal'],
             },
           },
           date: {
@@ -231,6 +253,18 @@ export function getDocumentTools(client: HoldedClient) {
           currency: {
             type: 'string',
             description: 'Currency code (e.g., EUR, USD)',
+          },
+          invoiceNum: {
+            type: 'string',
+            description: 'Document reference number (e.g. invoice number from supplier)',
+          },
+          salesChannelId: {
+            type: 'string',
+            description: 'Sales channel ID to associate with the document',
+          },
+          expAccountId: {
+            type: 'string',
+            description: 'Expense account ID for expense documents',
           },
         },
         required: ['docType', 'contactId', 'items', 'date'],
@@ -312,6 +346,37 @@ export function getDocumentTools(client: HoldedClient) {
           items: {
             type: 'array',
             description: 'Array of line items',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string', description: 'Product or service name' },
+                units: { type: 'number', description: 'Quantity of units' },
+                subtotal: {
+                  type: 'number',
+                  description: 'Line subtotal (price × units before tax/discount)',
+                },
+                desc: { type: 'string', description: 'Optional line description' },
+                sku: { type: 'string', description: 'SKU / product reference code' },
+                tax: {
+                  type: 'number',
+                  description: 'Tax percentage (0–100) — alternative to taxes array',
+                },
+                taxes: {
+                  type: 'array',
+                  description:
+                    'Holded tax ID(s) for the line item (max 1 element). Use instead of tax when referencing a specific Holded tax definition.',
+                  items: { type: 'string' },
+                  minItems: 1,
+                  maxItems: 1,
+                },
+                discount: { type: 'number', description: 'Discount percentage (0–100)' },
+                serviceId: {
+                  type: 'string',
+                  description: 'Service ID to link to a Holded service catalog entry',
+                },
+              },
+              required: ['name', 'units', 'subtotal'],
+            },
           },
           date: {
             type: 'number',
@@ -324,6 +389,18 @@ export function getDocumentTools(client: HoldedClient) {
           currency: {
             type: 'string',
             description: 'Currency code (e.g., EUR, USD)',
+          },
+          invoiceNum: {
+            type: 'string',
+            description: 'Document reference number (e.g. invoice number from supplier)',
+          },
+          salesChannelId: {
+            type: 'string',
+            description: 'Sales channel ID to associate with the document',
+          },
+          expAccountId: {
+            type: 'string',
+            description: 'Expense account ID for expense documents',
           },
         },
         required: ['docType', 'documentId'],

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -4,6 +4,31 @@ import { z } from 'zod';
  * Common validation schemas
  */
 
+/**
+ * Shared enum of all document types supported by the Holded API.
+ *
+ * Using a single shared constant ensures every schema that references document
+ * types stays in sync automatically. Adding a new document type here
+ * propagates to ALL schemas that use `docTypeEnum` — no risk of partial updates.
+ *
+ * @example
+ *   docTypeEnum.parse('invoice');   // OK
+ *   docTypeEnum.parse('unknown');   // throws ZodError
+ */
+export const docTypeEnum = z.enum([
+  'invoice',
+  'salesreceipt',
+  'creditnote',
+  'receiptnote',
+  'estimate',
+  'salesorder',
+  'waybill',
+  'proform',
+  'purchase',
+  'purchaserefund',
+  'purchaseorder',
+]);
+
 // Pagination schemas
 export const paginationSchema = z.object({
   page: z.number().int().positive().optional(),
@@ -70,106 +95,88 @@ export const contactAttachmentSchema = z.object({
   attachmentId: z.string().min(1),
 });
 
+/**
+ * Schema for a single line item within a document.
+ *
+ * Required fields: name, units, subtotal.
+ * Optional fields: desc, sku, tax (percentage), taxes (Holded tax IDs),
+ * discount, serviceId.
+ *
+ * Uses `.passthrough()` to allow additional fields not listed here, ensuring
+ * forward compatibility with Holded API changes.
+ */
+export const documentItemSchema = z
+  .object({
+    /** Product or service name shown on the document line */
+    name: z.string(),
+    /** Quantity of units */
+    units: z.number(),
+    /** Line subtotal (price × units before tax/discount) */
+    subtotal: z.number(),
+    /** Optional line description */
+    desc: z.string().optional(),
+    /** SKU / product reference code */
+    sku: z.string().optional(),
+    /** Tax percentage (0–100) — alternative to `taxes` */
+    tax: z.number().min(0).max(100).optional(),
+    /**
+     * Holded tax ID(s) for the line item.
+     * Accepts exactly 1 tax ID when provided; an empty array is rejected.
+     * Use this instead of `tax` when you need to reference a specific Holded tax definition.
+     */
+    taxes: z.array(z.string()).min(1).max(1).optional(),
+    /** Discount percentage (0–100) */
+    discount: z.number().min(0).max(100).optional(),
+    /** Service ID to link the line to a Holded service catalog entry */
+    serviceId: z.string().optional(),
+  })
+  .passthrough();
+
 // Document schemas
 export const documentIdSchema = z.object({
-  docType: z.enum([
-    'invoice',
-    'estimate',
-    'salesorder',
-    'purchaseorder',
-    'waybill',
-    'proform',
-    'purchase',
-  ]),
+  docType: docTypeEnum,
   documentId: z.string().min(1),
 });
 
 export const listDocumentsSchema = z
   .object({
-    docType: z.enum([
-      'invoice',
-      'estimate',
-      'salesorder',
-      'purchaseorder',
-      'waybill',
-      'proform',
-      'purchase',
-    ]),
+    docType: docTypeEnum,
   })
   .merge(paginationSchema)
   .merge(fieldFilteringSchema)
   .merge(dateRangeSchema);
 
 export const updateDocumentPipelineSchema = z.object({
-  docType: z.enum([
-    'invoice',
-    'estimate',
-    'salesorder',
-    'purchaseorder',
-    'waybill',
-    'proform',
-    'purchase',
-  ]),
+  docType: docTypeEnum,
   documentId: z.string().min(1),
   pipelineId: z.string().min(1),
   stageId: z.string().min(1),
 });
 
 export const attachFileToDocumentSchema = z.object({
-  docType: z.enum([
-    'invoice',
-    'estimate',
-    'salesorder',
-    'purchaseorder',
-    'waybill',
-    'proform',
-    'purchase',
-  ]),
+  docType: docTypeEnum,
   documentId: z.string().min(1),
   fileBase64: z.string().min(1),
   filename: z.string().min(1),
 });
 
 export const shipItemsByLineSchema = z.object({
-  docType: z.enum([
-    'invoice',
-    'estimate',
-    'salesorder',
-    'purchaseorder',
-    'waybill',
-    'proform',
-    'purchase',
-  ]),
+  docType: docTypeEnum,
   documentId: z.string().min(1),
   lines: z.array(z.unknown()),
 });
 
 export const payDocumentSchema = z.object({
-  docType: z.enum([
-    'invoice',
-    'estimate',
-    'salesorder',
-    'purchaseorder',
-    'waybill',
-    'proform',
-    'purchase',
-  ]),
+  docType: docTypeEnum,
   documentId: z.string().min(1),
   amount: z.number().nonnegative().optional(),
-  date: z.number().optional(),
+  /** Payment date as Unix timestamp integer. */
+  date: z.number().int().optional(),
   treasuryId: z.string().optional(),
 });
 
 export const sendDocumentSchema = z.object({
-  docType: z.enum([
-    'invoice',
-    'estimate',
-    'salesorder',
-    'purchaseorder',
-    'waybill',
-    'proform',
-    'purchase',
-  ]),
+  docType: docTypeEnum,
   documentId: z.string().min(1),
   emails: z.array(z.string().email()).optional(),
   subject: z.string().optional(),
@@ -177,36 +184,16 @@ export const sendDocumentSchema = z.object({
 });
 
 export const updateDocumentTrackingSchema = z.object({
-  docType: z.enum([
-    'invoice',
-    'estimate',
-    'salesorder',
-    'purchaseorder',
-    'waybill',
-    'proform',
-    'purchase',
-  ]),
+  docType: docTypeEnum,
   documentId: z.string().min(1),
   trackingNumber: z.string().optional(),
   carrier: z.string().optional(),
 });
 
 export const createDocumentSchema = z.object({
-  docType: z.enum([
-    'invoice',
-    'salesreceipt',
-    'creditnote',
-    'receiptnote',
-    'estimate',
-    'salesorder',
-    'waybill',
-    'proform',
-    'purchase',
-    'purchaserefund',
-    'purchaseorder',
-  ]),
+  docType: docTypeEnum,
   contactId: z.string().min(1),
-  items: z.array(z.unknown()),
+  items: z.array(documentItemSchema),
   /**
    * Document date as Unix timestamp (integer). Required by the Holded API.
    * If omitted, Holded will reject the request. Use Math.floor(Date.now() / 1000)
@@ -215,12 +202,18 @@ export const createDocumentSchema = z.object({
   date: z.number().int(),
   notes: z.string().optional(),
   currency: z.string().optional(),
+  /** Document reference number (e.g. invoice number from supplier) */
+  invoiceNum: z.string().optional(),
+  /** Sales channel ID to associate with the document */
+  salesChannelId: z.string().optional(),
+  /** Expense account ID for expense documents */
+  expAccountId: z.string().optional(),
 });
 
 export const updateDocumentSchema = documentIdSchema.merge(
   z.object({
     contactId: z.string().optional(),
-    items: z.array(z.unknown()).optional(),
+    items: z.array(documentItemSchema).optional(),
     /**
      * Document date as Unix timestamp (integer).
      * Required by the Holded API when updating the date field.
@@ -228,6 +221,12 @@ export const updateDocumentSchema = documentIdSchema.merge(
     date: z.number().int().optional(),
     notes: z.string().optional(),
     currency: z.string().optional(),
+    /** Document reference number (e.g. invoice number from supplier) */
+    invoiceNum: z.string().optional(),
+    /** Sales channel ID to associate with the document */
+    salesChannelId: z.string().optional(),
+    /** Expense account ID for expense documents */
+    expAccountId: z.string().optional(),
   })
 );
 
@@ -324,36 +323,12 @@ export const updatePaymentSchema = paymentIdSchema.merge(createPaymentSchema.par
 
 // Numbering series schemas
 export const numberingSerieIdSchema = z.object({
-  docType: z.enum([
-    'invoice',
-    'salesreceipt',
-    'creditnote',
-    'receiptnote',
-    'estimate',
-    'salesorder',
-    'waybill',
-    'proform',
-    'purchase',
-    'purchaserefund',
-    'purchaseorder',
-  ]),
+  docType: docTypeEnum,
   serieId: z.string().min(1),
 });
 
 export const createNumberingSerieSchema = z.object({
-  docType: z.enum([
-    'invoice',
-    'salesreceipt',
-    'creditnote',
-    'receiptnote',
-    'estimate',
-    'salesorder',
-    'waybill',
-    'proform',
-    'purchase',
-    'purchaserefund',
-    'purchaseorder',
-  ]),
+  docType: docTypeEnum,
   name: z.string().min(1),
   prefix: z.string().optional(),
   nextNumber: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary
Implements improvements from #38 (based on @n3b0r's work in #34) plus critical fixes found during code review.

- **`documentItemSchema`**: Proper Zod validation for line items replacing `z.unknown()` — requires `name`, `units`, `subtotal`; optional `desc`, `sku`, `tax`, `taxes`, `discount`, `serviceId`
- **`invoiceNum`**: Document reference number for supplier invoices
- **`taxes`**: Array of Holded tax IDs per line item (max 1, alongside existing `tax` field for backward compat)
- **`salesChannelId`** and **`expAccountId`**: New optional fields for document creation/update
- **`docTypeEnum`**: Shared constant replacing 10+ copy-pasted enums — fixes critical bug where 8 schemas were missing `salesreceipt`, `creditnote`, `receiptnote`, `purchaserefund`
- **`payDocumentSchema.date`**: Added missing `.int()` constraint

## Test plan
- [x] All 212 tests pass (52 new)
- [x] documentItemSchema validates required/optional fields correctly
- [x] taxes rejects empty arrays and arrays with >1 element
- [x] docTypeEnum regression test verifies all 11 types across all 10+ schemas
- [x] payDocumentSchema.date rejects float timestamps
- [x] update_document rejects items missing required fields

Closes #38

Credit: Based on improvements by @n3b0r (#34)