### PR TITLE
fix: default approveDoc to true in create_document (#51)

### DIFF
--- a/src/__tests__/documents.test.ts
+++ b/src/__tests__/documents.test.ts
@@ -107,6 +107,7 @@ describe('Document Tools', () => {
         contactId: 'contact-123',
         items: [{ name: 'Item 1', units: 1, subtotal: 100 }],
         date: 1700000000,
+        approveDoc: true,
       });
     });
 
@@ -147,6 +148,7 @@ describe('Document Tools', () => {
         date: 1700000000,
         notes: 'Test notes',
         currency: 'EUR',
+        approveDoc: true,
       });
     });
 
@@ -163,6 +165,7 @@ describe('Document Tools', () => {
         contactId: 'contact-456',
         items: [{ name: 'Service', units: 1, subtotal: 200 }],
         date: now,
+        approveDoc: true,
       });
     });
 
@@ -185,8 +188,66 @@ describe('Document Tools', () => {
           contactId: 'contact-123',
           items: [],
           date: 1700000000,
+          approveDoc: true,
         });
       }
+    });
+
+    describe('approveDoc parameter', () => {
+      it('should default approveDoc to true when omitted, finalizing the document', async () => {
+        // Regression test for github issue #51: without approveDoc the Holded API
+        // creates documents as drafts that are invisible in the UI.
+        await tools.create_document.handler({
+          docType: 'invoice' as const,
+          contactId: 'contact-123',
+          items: [{ name: 'Item', units: 1, subtotal: 100 }],
+          date: 1700000000,
+        });
+        const callBody = (client.post as any).mock.calls[0][1];
+        expect(callBody.approveDoc).toBe(true);
+      });
+
+      it('should forward approveDoc:true explicitly', async () => {
+        await tools.create_document.handler({
+          docType: 'invoice' as const,
+          contactId: 'contact-123',
+          items: [{ name: 'Item', units: 1, subtotal: 100 }],
+          date: 1700000000,
+          approveDoc: true,
+        });
+        const callBody = (client.post as any).mock.calls[0][1];
+        expect(callBody.approveDoc).toBe(true);
+      });
+
+      it('should forward approveDoc:false to intentionally create a draft', async () => {
+        await tools.create_document.handler({
+          docType: 'invoice' as const,
+          contactId: 'contact-123',
+          items: [{ name: 'Item', units: 1, subtotal: 100 }],
+          date: 1700000000,
+          approveDoc: false,
+        });
+        const callBody = (client.post as any).mock.calls[0][1];
+        expect(callBody.approveDoc).toBe(false);
+      });
+
+      it('should reject approveDoc with a non-boolean value', async () => {
+        await expect(
+          tools.create_document.handler({
+            docType: 'invoice' as const,
+            contactId: 'contact-123',
+            items: [],
+            date: 1700000000,
+            approveDoc: 'yes' as any,
+          })
+        ).rejects.toThrow();
+      });
+
+      it('should include approveDoc in create_document inputSchema as boolean', () => {
+        const props = tools.create_document.inputSchema.properties as any;
+        expect(props).toHaveProperty('approveDoc');
+        expect(props.approveDoc.type).toBe('boolean');
+      });
     });
   });
 
@@ -445,6 +506,7 @@ describe('Document Tools', () => {
         items: [{ name: 'Part A', units: 2, subtotal: 50 }],
         date: 1700000000,
         invoiceNum: 'PROV-2024-001',
+        approveDoc: true,
       });
     });
 
@@ -533,6 +595,7 @@ describe('Document Tools', () => {
         contactId: 'contact-123',
         items: [{ name: 'Service A', units: 1, subtotal: 200, taxes: ['holded-tax-123'] }],
         date: 1700000000,
+        approveDoc: true,
       });
     });
   });
@@ -559,6 +622,7 @@ describe('Document Tools', () => {
         items: [{ name: 'Item', units: 1, subtotal: 100 }],
         date: 1700000000,
         salesChannelId: 'channel-abc',
+        approveDoc: true,
       });
     });
 
@@ -596,6 +660,7 @@ describe('Document Tools', () => {
         items: [{ name: 'Office Supply', units: 1, subtotal: 50 }],
         date: 1700000000,
         expAccountId: 'exp-account-456',
+        approveDoc: true,
       });
     });
 

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -182,7 +182,8 @@ export function getDocumentTools(client: HoldedClient) {
 
     // Create Document
     create_document: {
-      description: 'Create a new document (invoice, estimate, etc.)',
+      description:
+        'Create a new document (invoice, estimate, etc.). By default the document is approved (finalized) so it appears in the Holded UI; pass approveDoc:false to create a draft instead.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -266,12 +267,18 @@ export function getDocumentTools(client: HoldedClient) {
             type: 'string',
             description: 'Expense account ID for expense documents',
           },
+          approveDoc: {
+            type: 'boolean',
+            description:
+              'Whether to immediately approve (finalize) the document instead of saving it as a draft. Defaults to true so the document is visible in the Holded UI. When the Holded API receives no value it defaults to draft, and drafts do not appear in Sales > Invoices, the contact Sales tab or global search. Pass false only when you intentionally want a draft. Note: approved documents are permanently locked by Holded.',
+          },
         },
         required: ['docType', 'contactId', 'items', 'date'],
       },
       destructiveHint: true,
       handler: withValidation(createDocumentSchema, async (args) => {
-        const { docType, ...body } = args;
+        const { docType, approveDoc, ...rest } = args;
+        const body = { ...rest, approveDoc: approveDoc ?? true };
         return client.post(`/documents/${docType}`, body);
       }),
     },

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -208,6 +208,20 @@ export const createDocumentSchema = z.object({
   salesChannelId: z.string().optional(),
   /** Expense account ID for expense documents */
   expAccountId: z.string().optional(),
+  /**
+   * Whether to immediately approve (finalize) the document instead of saving it as a draft.
+   *
+   * Defaults to `true` so created documents are visible in the Holded UI by default. When
+   * omitted, the Holded API itself defaults to `false` (draft), and drafts are hidden from
+   * the standard Sales > Invoices list, the contact's Sales tab and global search — they
+   * exist but are not reachable from the UI.
+   *
+   * Pass `false` explicitly only when you intentionally want a draft for later review.
+   *
+   * Note: once a document is approved it is permanently locked by Holded and cannot be
+   * deleted or freely edited.
+   */
+  approveDoc: z.boolean().optional(),
 });
 
 export const updateDocumentSchema = documentIdSchema.merge(


### PR DESCRIPTION
## Summary

Fixes #51. `create_document` was never sending `approveDoc`, so the Holded API defaulted it to `false` and every document was created as a draft. Drafts do not appear in `Sales > Invoices`, the contact's Sales tab, or global search, leaving programmatically created invoices unusable for production billing.

## Changes

- Add optional `approveDoc: boolean` to `createDocumentSchema` (Zod) and to the `create_document` JSON inputSchema
- Default `approveDoc` to `true` in the handler so documents are finalized and visible by default
- Allow `approveDoc: false` for intentional draft creation
- Update existing tests to match the new default body
- Add regression tests for default behavior, explicit `true`, explicit `false`, and rejection of non-boolean values

## Why default `true`

- Matches the expectation of the bug reporter and the UI's primary action ("Save & Approve")
- The 99% use case is finalizing real invoices/estimates; drafts are an explicit opt-in
- Without a default, the Holded API silently creates drafts that are hidden from the UI — that is what triggered the bug

## Caveats acknowledged in the schema description

- Approved documents are **permanently locked** by Holded and cannot be deleted or freely edited
- Callers wanting drafts can still pass `approveDoc: false`

## Test plan

- [x] `npm test` — 217/217 passing (5 new regression tests for `approveDoc`)
- [x] `npm run build` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — no new warnings (existing `any` warnings unrelated to this change)
- [ ] Manual smoke test against a real Holded sandbox tenant (recommended before merge)

## Out of scope

A separate `approve_document` tool to promote existing drafts. The Holded REST API doesn't document a public state-transition endpoint that I could verify, so I'm not adding one speculatively. If needed, it can be tracked in a follow-up issue.

Closes #51