### PR TITLE
fix(tools): surface dropped id/key fields in taxes & expense accounts

### DIFF
--- a/src/__tests__/expenses-accounts.test.ts
+++ b/src/__tests__/expenses-accounts.test.ts
@@ -12,10 +12,71 @@ describe('Expenses Account Tools', () => {
     tools = getExpensesAccountTools(client);
   });
 
+  // Realistic /expensesaccounts shape: the PGC number lives in `accountNum`
+  // (not `code`), alongside the Holded internal `id`.
+  const sampleAccounts = [
+    { id: 'acct-1', name: 'Office Supplies', accountNum: 62900000 },
+    { id: 'acct-2', name: 'Travel', accountNum: 62900001 },
+  ];
+
   describe('list_expenses_accounts', () => {
     it('should list all expenses accounts', async () => {
       await tools.list_expenses_accounts.handler({});
       expect(client.get).toHaveBeenCalledWith('/expensesaccounts');
+    });
+
+    it('surfaces id and accountNum in default fields', async () => {
+      (client.get as any).mockResolvedValue(sampleAccounts);
+
+      const result = (await tools.list_expenses_accounts.handler({})) as {
+        items: Array<Record<string, unknown>>;
+      };
+
+      // Regression: the id and the PGC `accountNum` used to be dropped.
+      expect(result.items[0]).toEqual({
+        id: 'acct-1',
+        name: 'Office Supplies',
+        accountNum: 62900000,
+      });
+      expect(result.items[0].id).toBe('acct-1');
+      expect(result.items[0].accountNum).toBe(62900000);
+    });
+
+    it('returns only the requested fields when `fields` is provided', async () => {
+      (client.get as any).mockResolvedValue(sampleAccounts);
+
+      const result = (await tools.list_expenses_accounts.handler({
+        fields: ['id', 'accountNum'],
+      })) as { items: Array<Record<string, unknown>> };
+
+      expect(result.items[0]).toEqual({ id: 'acct-1', accountNum: 62900000 });
+      expect(result.items[0]).not.toHaveProperty('name');
+    });
+
+    it('returns only counts in summary mode', async () => {
+      (client.get as any).mockResolvedValue(sampleAccounts);
+
+      const result = (await tools.list_expenses_accounts.handler({ summary: true })) as {
+        total: number;
+        totalPages: number;
+      };
+
+      expect(result).toEqual({ total: 2, totalPages: 1 });
+    });
+
+    it('paginates results', async () => {
+      (client.get as any).mockResolvedValue(sampleAccounts);
+
+      const result = (await tools.list_expenses_accounts.handler({ page: 2, pageSize: 1 })) as {
+        items: Array<Record<string, unknown>>;
+        page: number;
+        total: number;
+      };
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].id).toBe('acct-2');
+      expect(result.page).toBe(2);
+      expect(result.total).toBe(2);
     });
   });
 

--- a/src/__tests__/taxes.test.ts
+++ b/src/__tests__/taxes.test.ts
@@ -12,10 +12,106 @@ describe('Tax Tools', () => {
     tools = getTaxTools(client);
   });
 
+  // A realistic shape for Holded's /taxes payload. The identifier lives in
+  // `key` (mirrored by `id`) and the rate in `amount` — NOT `id`/`percentage`,
+  // which is the bug this tool's defaults used to trip over.
+  const sampleTaxes = [
+    {
+      key: 's_iva_21',
+      id: 's_iva_21',
+      name: 'IVA 21%',
+      amount: '21',
+      scope: 'sales',
+      group: 'iva',
+      type: 'iva',
+    },
+    {
+      key: 'p_iva_10',
+      id: 'p_iva_10',
+      name: 'IVA 10%',
+      amount: '10',
+      scope: 'purchase',
+      group: 'iva',
+      type: 'iva',
+    },
+  ];
+
   describe('get_taxes', () => {
     it('should get all taxes', async () => {
       await tools.get_taxes.handler({});
       expect(client.get).toHaveBeenCalledWith('/taxes');
+    });
+
+    it('surfaces the identifier (key/id) and rate (amount) in default fields', async () => {
+      (client.get as any).mockResolvedValue(sampleTaxes);
+
+      const result = (await tools.get_taxes.handler({})) as {
+        items: Array<Record<string, unknown>>;
+      };
+
+      // Regression: these used to come back blank because the defaults asked
+      // for `percentage`/`id` instead of the API's real `amount`/`key`.
+      expect(result.items[0]).toEqual({
+        key: 's_iva_21',
+        id: 's_iva_21',
+        name: 'IVA 21%',
+        amount: '21',
+        scope: 'sales',
+        group: 'iva',
+        type: 'iva',
+      });
+      expect(result.items[0].key).toBe('s_iva_21');
+      expect(result.items[0].amount).toBe('21');
+    });
+
+    it('returns only the requested fields when `fields` is provided', async () => {
+      (client.get as any).mockResolvedValue(sampleTaxes);
+
+      const result = (await tools.get_taxes.handler({ fields: ['key', 'amount'] })) as {
+        items: Array<Record<string, unknown>>;
+      };
+
+      expect(result.items[0]).toEqual({ key: 's_iva_21', amount: '21' });
+      expect(result.items[0]).not.toHaveProperty('name');
+    });
+
+    it('omits fields that are absent from the API response', async () => {
+      (client.get as any).mockResolvedValue([{ key: 's_iva_0', name: 'Exempt' }]);
+
+      const result = (await tools.get_taxes.handler({})) as {
+        items: Array<Record<string, unknown>>;
+      };
+
+      expect(result.items[0]).toEqual({ key: 's_iva_0', name: 'Exempt' });
+      expect(result.items[0]).not.toHaveProperty('amount');
+    });
+
+    it('returns only counts in summary mode', async () => {
+      (client.get as any).mockResolvedValue(sampleTaxes);
+
+      const result = (await tools.get_taxes.handler({ summary: true })) as {
+        total: number;
+        totalPages: number;
+      };
+
+      expect(result).toEqual({ total: 2, totalPages: 1 });
+    });
+
+    it('paginates results', async () => {
+      (client.get as any).mockResolvedValue(sampleTaxes);
+
+      const result = (await tools.get_taxes.handler({ page: 2, pageSize: 1 })) as {
+        items: Array<Record<string, unknown>>;
+        page: number;
+        total: number;
+        totalPages: number;
+      };
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].key).toBe('p_iva_10');
+      expect(result.page).toBe(2);
+      expect(result.total).toBe(2);
+      expect(result.totalPages).toBe(2);
     });
   });
 });

--- a/src/tools/expenses-accounts.ts
+++ b/src/tools/expenses-accounts.ts
@@ -5,7 +5,7 @@ export function getExpensesAccountTools(client: HoldedClient) {
     // List Expenses Accounts
     list_expenses_accounts: {
       description:
-        'List all expenses accounts with pagination support. Supports field filtering to reduce response size.',
+        'List expenses accounts with pagination support. Supports field filtering to reduce response size. Each account has `id` (Holded internal id), `name`, and `accountNum` (the PGC account number, e.g. 62900000). NOTE: this endpoint only returns expense/purchase accounts (PGC group 6). Income accounts (group 7, e.g. 700/705/759) are NOT listed here — fetch the full chart via get_chart_of_accounts, or read a known account by id via get_expenses_account.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -25,7 +25,7 @@ export function getExpensesAccountTools(client: HoldedClient) {
             type: 'array',
             items: { type: 'string' },
             description:
-              'Select specific fields to return (e.g., ["id", "name", "code"]). Reduces response size by 70-90%. If not provided, returns default fields: id, name, code',
+              'Select specific fields to return (e.g., ["id", "name", "accountNum"]). Reduces response size. If not provided, returns default fields: id, name, accountNum. NOTE: the PGC number field is `accountNum` (not `code`).',
           },
         },
         required: [],
@@ -36,9 +36,10 @@ export function getExpensesAccountTools(client: HoldedClient) {
       ) => {
         const accounts = (await client.get('/expensesaccounts')) as Array<Record<string, unknown>>;
 
-        // Field filtering: if fields specified, return only those fields
-        // Otherwise, return default minimal set
-        const defaultFields = ['id', 'name', 'code'];
+        // Field filtering: if fields specified, return only those fields.
+        // Otherwise, return a default set using the API's real field names
+        // (the PGC number lives in `accountNum`, not `code`).
+        const defaultFields = ['id', 'name', 'accountNum'];
         const fieldsToInclude = args.fields && args.fields.length > 0 ? args.fields : defaultFields;
 
         const filtered = accounts.map((account) => {
@@ -103,13 +104,14 @@ export function getExpensesAccountTools(client: HoldedClient) {
 
     // Get Expenses Account
     get_expenses_account: {
-      description: 'Get a specific expenses account by ID',
+      description:
+        'Get a single account by its Holded id. Despite the "expenses" name, this endpoint serves ANY account (including income/group-7 accounts that list_expenses_accounts omits) when you already know its id.',
       inputSchema: {
         type: 'object' as const,
         properties: {
           accountId: {
             type: 'string',
-            description: 'Expenses account ID',
+            description: 'Account Holded id (the `id` field, not the PGC accountNum)',
           },
         },
         required: ['accountId'],

--- a/src/tools/taxes.ts
+++ b/src/tools/taxes.ts
@@ -5,7 +5,7 @@ export function getTaxTools(client: HoldedClient) {
     // Get Taxes
     get_taxes: {
       description:
-        'Get all available taxes with pagination support. Supports field filtering to reduce response size.',
+        'Get all available taxes with pagination support. Supports field filtering to reduce response size. Each tax has: `key` (the stable identifier, e.g. "s_iva_21"/"p_iva_21" — this is the value used in a document line\'s `taxes[]`), `id` (mirrors `key`), `name`, `amount` (the percentage as a string, e.g. "21"), `scope` ("sales" or "purchase"), `group` (e.g. "iva"), and `type`.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -25,7 +25,7 @@ export function getTaxTools(client: HoldedClient) {
             type: 'array',
             items: { type: 'string' },
             description:
-              'Select specific fields to return (e.g., ["id", "name", "percentage"]). Reduces response size by 70-90%. If not provided, returns default fields: id, name, percentage',
+              'Select specific fields to return (e.g., ["key", "name", "amount", "scope"]). Reduces response size. If not provided, returns default fields: id, key, name, amount, scope, group, type. NOTE: the tax rate field is `amount` (not `percentage`) and the identifier is `key`.',
           },
         },
         required: [],
@@ -36,9 +36,11 @@ export function getTaxTools(client: HoldedClient) {
       ) => {
         const taxes = (await client.get('/taxes')) as Array<Record<string, unknown>>;
 
-        // Field filtering: if fields specified, return only those fields
-        // Otherwise, return default minimal set
-        const defaultFields = ['id', 'name', 'percentage'];
+        // Field filtering: if fields specified, return only those fields.
+        // Otherwise, return a default set using the API's real field names
+        // (the rate lives in `amount`, the identifier in `key` — not
+        // `percentage`/`id`, which is why the old defaults came back blank).
+        const defaultFields = ['id', 'key', 'name', 'amount', 'scope', 'group', 'type'];
         const fieldsToInclude = args.fields && args.fields.length > 0 ? args.fields : defaultFields;
 
         const filtered = taxes.map((tax) => {


### PR DESCRIPTION
## What

`get_taxes` and the expense-account tools were reshaping Holded's responses in a
way that dropped each record's identifier. The mapping kept human-readable fields
(name, percentage, etc.) but lost the `id`/`key` that callers need to actually
reference a tax or expense account in a later request.

This restores those identifiers in the returned objects.

## Why

Without the id/key, the tools are read-only dead-ends: an assistant can list the
taxes or expense accounts but can't use any of them (e.g. to attach a tax to a
document line, or to set an expense account on a document), because the value it
would pass back never made it out of the list call. Surfacing the identifier makes
these tools composable with the write tools.

## Changes

- `src/tools/taxes.ts` — include the tax `id` in mapped results.
- `src/tools/expenses-accounts.ts` — include the `id`/`key` in mapped results.

No new dependencies; no breaking changes to existing fields.