### PR TITLE
feat(documents): add write-safety guards & read-semantics warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Model Context Protocol (MCP) server for the Holded Invoice API. This server al
 
 This MCP server provides access to the complete Holded Invoice API:
 
-- **Documents** (16 tools): Create, list, update, delete invoices, estimates, credit notes, etc. Also pay, send, get PDF, ship items, and more.
+- **Documents** (17 tools): Create, list, update, delete invoices, estimates, credit notes, etc. Also pay, send, get PDF, ship items, read a document's payments (`get_document_payments`), and more.
 - **Contacts** (7 tools): Manage clients and suppliers with attachments.
 - **Products** (9 tools): Full product management including images and stock.
 - **Treasuries** (3 tools): Manage treasury accounts.
@@ -25,7 +25,7 @@ This MCP server provides access to the complete Holded Invoice API:
 - **Remittances** (2 tools): Access remittance data.
 - **Services** (5 tools): Manage services.
 
-**Total: 72 tools**
+**Total: 73 tools**
 
 ## Installation
 
@@ -108,6 +108,14 @@ Once configured, you can ask Claude to:
 - "Send invoice #123 to the client by email"
 - "Get the PDF of invoice #456"
 - "Mark invoice #789 as paid"
+- "Show me the payments registered against invoice #789"
+
+> **Write-safety note:** Holded's write API returns a success even when it
+> silently ignores a field. The document/payment write tools re-read the record
+> after a write and surface a non-fatal `_warnings[]` array (e.g. a numbering
+> series overriding the requested `invoiceNum`, a currency change that did not
+> persist, or a document that was auto-approved as a side effect of being paid)
+> so the result reflects what Holded actually stored.
 
 ### Contacts
 

--- a/src/__tests__/documents.test.ts
+++ b/src/__tests__/documents.test.ts
@@ -959,6 +959,142 @@ describe('Document Tools', () => {
     });
   });
 
+  describe('write-safety guards (EXTENSIONS #7-#17)', () => {
+    it('#7 rejects a line-level `account` on create (use expAccountId instead)', async () => {
+      await expect(
+        tools.create_document.handler({
+          docType: 'purchase' as const,
+          contactId: 'contact-1',
+          items: [{ name: 'Item', units: 1, subtotal: 50, account: 60000000 } as any],
+          date: 1700000000,
+        })
+      ).rejects.toThrow(/expAccountId/);
+    });
+
+    it('#7 rejects a line-level `account` on update', async () => {
+      await expect(
+        tools.update_document.handler({
+          docType: 'invoice' as const,
+          documentId: 'doc-1',
+          items: [{ name: 'Item', units: 1, subtotal: 50, account: 70000000 } as any],
+        })
+      ).rejects.toThrow(/expAccountId/);
+    });
+
+    it('#11 rejects `retention` on a purchase document', async () => {
+      await expect(
+        tools.create_document.handler({
+          docType: 'purchase' as const,
+          contactId: 'contact-1',
+          items: [{ name: 'Item', units: 1, subtotal: 50 }],
+          date: 1700000000,
+          retention: 15,
+        } as any)
+      ).rejects.toThrow(/retention/i);
+    });
+
+    it('#11 allows `retention` on a sales document and forwards it', async () => {
+      await tools.create_document.handler({
+        docType: 'invoice' as const,
+        contactId: 'contact-1',
+        items: [{ name: 'Service', units: 1, subtotal: 100 }],
+        date: 1700000000,
+        retention: 15,
+      } as any);
+      expect(client.post).toHaveBeenCalledWith('/documents/invoice', {
+        contactId: 'contact-1',
+        items: [{ name: 'Service', units: 1, subtotal: 100 }],
+        date: 1700000000,
+        retention: 15,
+        approveDoc: true,
+      });
+    });
+
+    it('#17 warns when a sales numbering series overrides the requested invoiceNum', async () => {
+      client.post = vi.fn().mockResolvedValue({ id: 'doc-new' });
+      client.get = vi.fn().mockResolvedValue({ invoiceNum: 'FAC-2025-0001' });
+      const result = (await tools.create_document.handler({
+        docType: 'invoice' as const,
+        contactId: 'contact-1',
+        items: [{ name: 'Service', units: 1, subtotal: 100 }],
+        date: 1700000000,
+        invoiceNum: 'CUSTOM-1',
+      })) as any;
+      expect(client.get).toHaveBeenCalledWith('/documents/invoice/doc-new');
+      expect(result._warnings).toBeDefined();
+      expect(result._warnings[0]).toMatch(/overridden/);
+    });
+
+    it('#17 does not re-read or warn for invoiceNum on a purchase (supplier number preserved)', async () => {
+      client.post = vi.fn().mockResolvedValue({ id: 'doc-new' });
+      client.get = vi.fn().mockResolvedValue({ invoiceNum: 'SOMETHING-ELSE' });
+      const result = (await tools.create_document.handler({
+        docType: 'purchase' as const,
+        contactId: 'contact-1',
+        items: [{ name: 'Part', units: 1, subtotal: 50 }],
+        date: 1700000000,
+        invoiceNum: 'PROV-001',
+      })) as any;
+      expect(client.get).not.toHaveBeenCalled();
+      expect(result._warnings).toBeUndefined();
+    });
+
+    it('#12 warns that a currency change was ignored on update', async () => {
+      client.put = vi.fn().mockResolvedValue({ status: 1 });
+      client.get = vi.fn().mockResolvedValue({ currency: 'EUR' });
+      const result = (await tools.update_document.handler({
+        docType: 'invoice' as const,
+        documentId: 'doc-1',
+        currency: 'USD',
+      })) as any;
+      expect(result._warnings).toBeDefined();
+      expect(result._warnings[0]).toMatch(/currency/i);
+    });
+
+    it('#10 pay_document always warns about the auto-approve side effect', async () => {
+      const result = (await tools.pay_document.handler({
+        docType: 'invoice' as const,
+        documentId: 'doc-1',
+        amount: 100,
+        date: 1700000000,
+      })) as any;
+      expect(result._warnings.some((w: string) => /auto-approved/i.test(w))).toBe(true);
+    });
+
+    it('#8 pay_document links bankId via a second PUT /payments step', async () => {
+      client.post = vi.fn().mockResolvedValue({ id: 'pay-result' });
+      client.get = vi.fn().mockResolvedValue({ paymentsDetail: [{ id: 'paydetail-1' }] });
+      client.put = vi.fn().mockResolvedValue({ status: 1 });
+      const result = (await tools.pay_document.handler({
+        docType: 'invoice' as const,
+        documentId: 'doc-1',
+        amount: 100,
+        bankId: 'bank-9',
+      })) as any;
+      expect(client.post).toHaveBeenCalledWith('/documents/invoice/doc-1/pay', { amount: 100 });
+      expect(client.put).toHaveBeenCalledWith('/payments/paydetail-1', { bankId: 'bank-9' });
+      expect(result._warnings.some((w: string) => /Linked bank account bank-9/.test(w))).toBe(true);
+    });
+
+    it('#16 maps the approved filter to Holded `filter=approved-<n>`', async () => {
+      await tools.list_documents.handler({ docType: 'invoice', approved: '0' });
+      expect(client.get).toHaveBeenCalledWith('/documents/invoice', { filter: 'approved-0' });
+    });
+
+    it('#14 get_document_payments returns the document paymentsDetail', async () => {
+      client.get = vi.fn().mockResolvedValue({ paymentsDetail: [{ id: 'p1', amount: 100 }] });
+      const result = (await tools.get_document_payments.handler({
+        docType: 'invoice' as const,
+        documentId: 'doc-1',
+      })) as any;
+      expect(client.get).toHaveBeenCalledWith('/documents/invoice/doc-1');
+      expect(result).toEqual({
+        documentId: 'doc-1',
+        paymentsDetail: [{ id: 'p1', amount: 100 }],
+      });
+    });
+  });
+
   describe('Virtual pagination', () => {
     it('should return first page of results with page=1', async () => {
       // Mock 100 documents

--- a/src/__tests__/documents.test.ts
+++ b/src/__tests__/documents.test.ts
@@ -959,7 +959,7 @@ describe('Document Tools', () => {
     });
   });
 
-  describe('write-safety guards (EXTENSIONS #7-#17)', () => {
+  describe('write-safety guards (silent-fail field handling)', () => {
     it('#7 rejects a line-level `account` on create (use expAccountId instead)', async () => {
       await expect(
         tools.create_document.handler({

--- a/src/__tests__/payments.test.ts
+++ b/src/__tests__/payments.test.ts
@@ -57,6 +57,25 @@ describe('Payment Tools', () => {
         days: 60,
       });
     });
+
+    it('#9 merges changes over the current payment so omitted fields are not blanked', async () => {
+      client.get = vi.fn().mockResolvedValue({
+        id: 'payment-123',
+        name: 'Bank Transfer',
+        days: 30,
+        contactId: 'contact-1',
+        bankId: 'bank-1',
+      });
+      await tools.update_payment.handler({ paymentId: 'payment-123', days: 60 });
+      expect(client.get).toHaveBeenCalledWith('/payments/payment-123');
+      // name/contactId/bankId preserved from the current record; days updated; id dropped.
+      expect(client.put).toHaveBeenCalledWith('/payments/payment-123', {
+        name: 'Bank Transfer',
+        days: 60,
+        contactId: 'contact-1',
+        bankId: 'bank-1',
+      });
+    });
   });
 
   describe('delete_payment', () => {

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -26,12 +26,36 @@ export type DocumentType =
   | 'purchaserefund'
   | 'purchaseorder';
 
+/** Document types Holded treats as purchases (supplier-side documents). */
+const PURCHASE_DOC_TYPES = new Set<DocumentType>(['purchase', 'purchaserefund', 'purchaseorder']);
+
+/**
+ * Attach non-fatal `_warnings` to a tool result without dropping the original
+ * payload. Holded frequently returns `{status:1, "Updated"}` even when it
+ * silently ignored a field, so write tools re-GET and surface discrepancies
+ * here rather than throwing (the write itself did happen).
+ *
+ * @param result - The raw Holded response.
+ * @param warnings - Human-readable warnings to surface to the caller.
+ * @returns The result unchanged when there are no warnings, otherwise the
+ *   result augmented with a `_warnings` array.
+ */
+function attachWarnings<T>(result: T, warnings: string[]): T {
+  if (warnings.length === 0) {
+    return result;
+  }
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    return { ...(result as object), _warnings: warnings } as T;
+  }
+  return { value: result, _warnings: warnings } as unknown as T;
+}
+
 export function getDocumentTools(client: HoldedClient) {
   return {
     // List Documents
     list_documents: {
       description:
-        'List all documents of a specific type with optional filters for date range, contact, payment status, and sorting. Supports field filtering to reduce response size.',
+        'List all documents of a specific type with optional filters for date range, contact, payment status, approval, and sorting. Supports field filtering to reduce response size. NOTE: a document carries three INDEPENDENT and sometimes-conflicting flags — (1) the stored Paid/Pending badge `status` (set when the document is imported, NOT recomputed), (2) the real outstanding amount `paymentsPending` (the authoritative math), and (3) approval (filter with `approved`). A document can be badge-Paid, math-unpaid, and not-approved all at once, so check the flag you actually mean.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -86,6 +110,12 @@ export function getDocumentTools(client: HoldedClient) {
             enum: ['0', '1'],
             description: 'Filter by billed status: 0=not billed, 1=billed',
           },
+          approved: {
+            type: 'string',
+            enum: ['0', '1'],
+            description:
+              'Filter by approval state: 0=not approved, 1=approved. Maps to Holded `filter=approved-<n>`. Independent of the Paid/Pending badge and of paymentsPending.',
+          },
           sort: {
             type: 'string',
             enum: ['created-asc', 'created-desc'],
@@ -95,7 +125,7 @@ export function getDocumentTools(client: HoldedClient) {
             type: 'array',
             items: { type: 'string' },
             description:
-              'Select specific fields to return (e.g., ["id", "contactName", "total"]). Reduces response size by 70-90%. If not provided, returns default fields: id, contact, contactName, date, tax, total, status',
+              'Select specific fields to return (e.g., ["id", "contactName", "total"]). Reduces response size by 70-90%. If not provided, returns default fields: id, contact, contactName, date, tax, total, status, paymentsPending',
           },
         },
         required: ['docType'],
@@ -111,6 +141,7 @@ export function getDocumentTools(client: HoldedClient) {
         contactid?: string;
         paid?: string;
         billed?: string;
+        approved?: string;
         sort?: string;
         fields?: string[];
       }) => {
@@ -128,13 +159,26 @@ export function getDocumentTools(client: HoldedClient) {
         if (args.contactid) queryParams.contactid = args.contactid;
         if (args.paid) queryParams.paid = args.paid;
         if (args.billed) queryParams.billed = args.billed;
+        // #16 — approval is a separate flag exposed via `filter=approved-<n>`.
+        if (args.approved) queryParams.filter = `approved-${args.approved}`;
         if (args.sort) queryParams.sort = args.sort;
         const result = await client.get(`/documents/${args.docType}`, queryParams);
         // Filter to return only essential fields
         if (Array.isArray(result)) {
           // Field filtering: if fields specified, return only those fields
-          // Otherwise, return default minimal set
-          const defaultFields = ['id', 'contact', 'contactName', 'date', 'tax', 'total', 'status'];
+          // Otherwise, return default minimal set. `status` is the stored
+          // Paid/Pending badge; `paymentsPending` is the authoritative
+          // outstanding-amount math — both are surfaced by default (#16).
+          const defaultFields = [
+            'id',
+            'contact',
+            'contactName',
+            'date',
+            'tax',
+            'total',
+            'status',
+            'paymentsPending',
+          ];
           const fieldsToInclude =
             args.fields && args.fields.length > 0 ? args.fields : defaultFields;
 
@@ -183,7 +227,7 @@ export function getDocumentTools(client: HoldedClient) {
     // Create Document
     create_document: {
       description:
-        'Create a new document (invoice, estimate, etc.). By default the document is approved (finalized) so it appears in the Holded UI; pass approveDoc:false to create a draft instead.',
+        'Create a new document (invoice, estimate, purchase, etc.). By default the document is approved (finalized) so it appears in the Holded UI; pass approveDoc:false to create a draft instead. Set the expense/income account at document level via `expAccountId` (it cascades to all lines); a per-line `account` is rejected because Holded ignores it. On SALES documents an auto-incrementing numbering series may OVERRIDE the requested `invoiceNum` — the tool re-reads the created document and returns a `_warnings` note if that happened. On purchases the supplier number in `invoiceNum` is preserved. `retention` (IRPF) is accepted on sales but rejected on purchases (Holded ignores it there).',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -279,7 +323,33 @@ export function getDocumentTools(client: HoldedClient) {
       handler: withValidation(createDocumentSchema, async (args) => {
         const { docType, approveDoc, ...rest } = args;
         const body = { ...rest, approveDoc: approveDoc ?? true };
-        return client.post(`/documents/${docType}`, body);
+        const result = (await client.post(`/documents/${docType}`, body)) as Record<
+          string,
+          unknown
+        >;
+        const warnings: string[] = [];
+        // #17 — on sales documents a numbering series may override the requested
+        // invoiceNum. Re-read the created document to confirm what actually stuck.
+        if (body.invoiceNum && !PURCHASE_DOC_TYPES.has(docType)) {
+          const newId = typeof result?.id === 'string' ? result.id : undefined;
+          if (newId) {
+            try {
+              const created = (await client.get(`/documents/${docType}/${newId}`)) as Record<
+                string,
+                unknown
+              >;
+              const persisted = created?.invoiceNum ?? created?.docNumber;
+              if (persisted !== undefined && persisted !== body.invoiceNum) {
+                warnings.push(
+                  `Requested invoiceNum "${body.invoiceNum}" was overridden by the numbering series to "${String(persisted)}".`
+                );
+              }
+            } catch {
+              // Best-effort verification; never fail a successful create on it.
+            }
+          }
+        }
+        return attachWarnings(result, warnings);
       }),
     },
 
@@ -316,6 +386,49 @@ export function getDocumentTools(client: HoldedClient) {
       readOnlyHint: true,
       handler: withValidation(documentIdSchema, async (args) => {
         return client.get(`/documents/${args.docType}/${args.documentId}`);
+      }),
+    },
+
+    // Get Document Payments (cross-year)
+    get_document_payments: {
+      description:
+        "Get the payments registered against a specific document, read directly from the document's `paymentsDetail`. Unlike list_payments — which is filtered to the ACTIVE fiscal year — this surfaces payments from ANY year, so use it for cross-year payment audits (e.g. an invoice dated last year that was paid this year). Returns `{ documentId, paymentsDetail }`. Read-only.",
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          docType: {
+            type: 'string',
+            enum: [
+              'invoice',
+              'salesreceipt',
+              'creditnote',
+              'receiptnote',
+              'estimate',
+              'salesorder',
+              'waybill',
+              'proform',
+              'purchase',
+              'purchaserefund',
+              'purchaseorder',
+            ],
+            description: 'Type of document',
+          },
+          documentId: {
+            type: 'string',
+            description: 'Document ID',
+          },
+        },
+        required: ['docType', 'documentId'],
+      },
+      readOnlyHint: true,
+      handler: withValidation(documentIdSchema, async (args) => {
+        const doc = (await client.get(`/documents/${args.docType}/${args.documentId}`)) as {
+          paymentsDetail?: unknown;
+        };
+        return {
+          documentId: args.documentId,
+          paymentsDetail: Array.isArray(doc?.paymentsDetail) ? doc.paymentsDetail : [],
+        };
       }),
     },
 
@@ -415,7 +528,35 @@ export function getDocumentTools(client: HoldedClient) {
       destructiveHint: true,
       handler: withValidation(updateDocumentSchema, async (args) => {
         const { docType, documentId, ...body } = args;
-        return client.put(`/documents/${docType}/${documentId}`, body);
+        const result = (await client.put(`/documents/${docType}/${documentId}`, body)) as Record<
+          string,
+          unknown
+        >;
+        const warnings: string[] = [];
+        // #12 — Holded ignores `currency`/`currencyChange` on PUT; the document
+        // keeps its original currency. Re-GET to confirm and warn if it didn't
+        // change, so the caller doesn't assume an FX conversion that never ran.
+        if (body.currency) {
+          try {
+            const current = (await client.get(`/documents/${docType}/${documentId}`)) as Record<
+              string,
+              unknown
+            >;
+            const persisted = current?.currency;
+            if (persisted !== undefined && persisted !== body.currency) {
+              warnings.push(
+                `Holded ignored the currency change to "${body.currency}" on update (still "${String(persisted)}"). Currency/FX can't be changed via the API — book in the target currency at the bank rate instead.`
+              );
+            } else if (persisted === undefined) {
+              warnings.push(
+                'Holded ignores currency/currencyChange on document update; the requested currency change may not have been applied. Verify in Holded.'
+              );
+            }
+          } catch {
+            // Best-effort verification; never fail a successful update on it.
+          }
+        }
+        return attachWarnings(result, warnings);
       }),
     },
 
@@ -457,7 +598,8 @@ export function getDocumentTools(client: HoldedClient) {
 
     // Pay Document
     pay_document: {
-      description: 'Register a payment for a document',
+      description:
+        "Register a payment for a document. IMPORTANT: this AUTO-APPROVES the document as a side effect (status 0→1) — Holded has no separate approve endpoint, and approval cannot be undone via the API. `paymentmethod` is the payment-method catalog id (from list_payment_methods), NOT a bank/treasury id. To link the payment to a bank account, pass `bankId`: the /pay endpoint can't set it, so the tool performs a second step (PUT /payments/{id}) and reports the outcome in `_warnings`.",
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -494,13 +636,54 @@ export function getDocumentTools(client: HoldedClient) {
             type: 'string',
             description: 'Treasury account ID',
           },
+          paymentmethod: {
+            type: 'string',
+            description:
+              'Payment-method catalog id (from list_payment_methods), NOT a bank/treasury id.',
+          },
+          bankId: {
+            type: 'string',
+            description:
+              'Bank account id to link the payment to. Triggers a second step (PUT /payments/{id}) because /pay cannot set the bank link.',
+          },
         },
         required: ['docType', 'documentId', 'amount'],
       },
       destructiveHint: true,
       handler: withValidation(payDocumentSchema, async (args) => {
-        const { docType, documentId, ...body } = args;
-        return client.post(`/documents/${docType}/${documentId}/pay`, body);
+        const { docType, documentId, bankId, ...payBody } = args;
+        const result = (await client.post(
+          `/documents/${docType}/${documentId}/pay`,
+          payBody
+        )) as Record<string, unknown>;
+        // #10 — paying always auto-approves the document; surface that clearly.
+        const warnings: string[] = [
+          'Registering a payment auto-approved the document (status 0→1). Holded has no API to approve without payment or to un-approve afterwards.',
+        ];
+        // #8 — the bank link is a separate step. Resolve the new payment id from
+        // the document's paymentsDetail, then PUT /payments/{id} with bankId.
+        if (bankId) {
+          try {
+            const doc = (await client.get(`/documents/${docType}/${documentId}`)) as {
+              paymentsDetail?: Array<{ id?: string }>;
+            };
+            const payments = Array.isArray(doc?.paymentsDetail) ? doc.paymentsDetail : [];
+            const newest = payments[payments.length - 1];
+            if (newest?.id) {
+              await client.put(`/payments/${newest.id}`, { bankId });
+              warnings.push(`Linked bank account ${bankId} to payment ${newest.id}.`);
+            } else {
+              warnings.push(
+                `Could not resolve the new payment id; set bankId ${bankId} manually via update_payment (PUT /payments/{id}).`
+              );
+            }
+          } catch (error) {
+            warnings.push(
+              `Bank-link step failed: ${error instanceof Error ? error.message : String(error)}. The payment was registered but not linked to bankId ${bankId}.`
+            );
+          }
+        }
+        return attachWarnings(result, warnings);
       }),
     },
 

--- a/src/tools/payments.ts
+++ b/src/tools/payments.ts
@@ -11,7 +11,7 @@ export function getPaymentTools(client: HoldedClient) {
     // List Payments
     list_payments: {
       description:
-        'List all payments with optional filters for date range. Supports field filtering to reduce response size.',
+        "List all payments with optional filters for date range. Supports field filtering to reduce response size. NOTE: this endpoint is filtered to the ACTIVE fiscal year, so payments made in a prior year do NOT appear here even if they are linked to documents. For cross-year payment audits, read a document's payments via get_document_payments (the document `paymentsDetail`).",
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -149,7 +149,8 @@ export function getPaymentTools(client: HoldedClient) {
 
     // Update Payment
     update_payment: {
-      description: 'Update an existing payment',
+      description:
+        "Update an existing payment. IMPORTANT: Holded's PUT /payments/{id} REPLACES the record rather than merging, so any field omitted from the body is blanked. To prevent that, this tool first re-reads the current payment and merges your changes over it, preserving fields you did not pass (contactId, bankId, date, ...).",
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -165,13 +166,41 @@ export function getPaymentTools(client: HoldedClient) {
             type: 'number',
             description: 'Days until due',
           },
+          bankId: {
+            type: 'string',
+            description: 'Bank account id to link the payment to',
+          },
+          contactId: {
+            type: 'string',
+            description: 'Contact id associated with the payment',
+          },
+          date: {
+            type: 'number',
+            description: 'Payment date as a Unix timestamp (seconds)',
+          },
+          amount: {
+            type: 'number',
+            description: 'Payment amount',
+          },
         },
         required: ['paymentId'],
       },
       destructiveHint: true,
       handler: withValidation(updatePaymentSchema, async (args) => {
-        const { paymentId, ...body } = args;
-        return client.put(`/payments/${paymentId}`, body);
+        const { paymentId, ...updates } = args;
+        // #9 — PUT /payments/{id} REPLACES the resource. Merge the requested
+        // changes over the current payment so unspecified fields aren't blanked.
+        let base: Record<string, unknown> = {};
+        try {
+          const current = await client.get(`/payments/${paymentId}`);
+          if (current && typeof current === 'object' && !Array.isArray(current)) {
+            base = { ...(current as Record<string, unknown>) };
+            delete base.id;
+          }
+        } catch {
+          // If the current payment can't be fetched, fall back to a plain update.
+        }
+        return client.put(`/payments/${paymentId}`, { ...base, ...updates });
       }),
     },
 

--- a/src/tools/treasuries.ts
+++ b/src/tools/treasuries.ts
@@ -6,7 +6,7 @@ export function getTreasuryTools(client: HoldedClient) {
     // List Treasuries Accounts
     list_treasuries: {
       description:
-        'List all treasury accounts with pagination support. Supports field filtering to reduce response size.',
+        'List all treasury accounts with pagination support. Supports field filtering to reduce response size. WARNING: the `balance` field is a STATIC opening figure, not a live balance derived from transactions — do NOT rely on it for reconciliation or to compute the current cash position.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -112,7 +112,8 @@ export function getTreasuryTools(client: HoldedClient) {
 
     // Get Treasury Account
     get_treasury: {
-      description: 'Get a specific treasury account by ID',
+      description:
+        'Get a specific treasury account by ID. WARNING: the `balance` field is a STATIC opening figure set on the account, not a live balance computed from transactions — do NOT use it for reconciliation or as the current cash position.',
       inputSchema: {
         type: 'object' as const,
         properties: {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -173,6 +173,19 @@ export const payDocumentSchema = z.object({
   /** Payment date as Unix timestamp integer. */
   date: z.number().int().optional(),
   treasuryId: z.string().optional(),
+  /**
+   * Payment-method catalog id (the `/paymentmethods` id), NOT a bank/treasury id.
+   * Holded's `/pay` endpoint treats the payment method and the bank link as two
+   * separate things — see `bankId`. (EXTENSIONS.md #8.)
+   */
+  paymentmethod: z.string().optional(),
+  /**
+   * Bank/treasury account id to associate the resulting payment with. The `/pay`
+   * endpoint does NOT accept this; the bank link can only be set via
+   * `PUT /payments/{id}` afterwards, so `pay_document` performs that second step
+   * when this is provided. (EXTENSIONS.md #8.)
+   */
+  bankId: z.string().optional(),
 });
 
 export const sendDocumentSchema = z.object({
@@ -190,49 +203,58 @@ export const updateDocumentTrackingSchema = z.object({
   carrier: z.string().optional(),
 });
 
-export const createDocumentSchema = z.object({
-  docType: docTypeEnum,
-  contactId: z.string().min(1),
-  items: z.array(documentItemSchema),
-  /**
-   * Document date as Unix timestamp (integer). Required by the Holded API.
-   * If omitted, Holded will reject the request. Use Math.floor(Date.now() / 1000)
-   * to get the current timestamp.
-   */
-  date: z.number().int(),
-  notes: z.string().optional(),
-  currency: z.string().optional(),
-  /** Document reference number (e.g. invoice number from supplier) */
-  invoiceNum: z.string().optional(),
-  /** Sales channel ID to associate with the document */
-  salesChannelId: z.string().optional(),
-  /** Expense account ID for expense documents */
-  expAccountId: z.string().optional(),
-  /**
-   * Whether to immediately approve (finalize) the document instead of saving it as a draft.
-   *
-   * Defaults to `true` so created documents are visible in the Holded UI by default. When
-   * omitted, the Holded API itself defaults to `false` (draft), and drafts are hidden from
-   * the standard Sales > Invoices list, the contact's Sales tab and global search — they
-   * exist but are not reachable from the UI.
-   *
-   * Pass `false` explicitly only when you intentionally want a draft for later review.
-   *
-   * Note: once a document is approved it is permanently locked by Holded and cannot be
-   * deleted or freely edited.
-   */
-  approveDoc: z.boolean().optional(),
-});
+/** Document types Holded treats as purchases (supplier-side documents). */
+export const PURCHASE_DOC_TYPES = new Set<string>(['purchase', 'purchaserefund', 'purchaseorder']);
 
-export const updateDocumentSchema = documentIdSchema.merge(
-  z.object({
-    contactId: z.string().optional(),
-    items: z.array(documentItemSchema).optional(),
+/**
+ * Cross-field validation shared by create/update document schemas. Rejects two
+ * silent-fail traps where Holded accepts a write but ignores the field, so the
+ * caller never learns the value was dropped:
+ *
+ * - **#7** — `account` on a line item. The expense/income account must be set at
+ *   document level via `expAccountId`, which cascades to every line; a line-level
+ *   `account` is silently ignored.
+ * - **#11** — `retention` (IRPF) on a purchase document. There is no API to set
+ *   it on purchases (UI-only), so accepting it would report a false success.
+ *
+ * @param data - The parsed document payload.
+ * @param ctx - Zod refinement context used to attach validation issues.
+ */
+function assertDocumentWriteSafety(
+  data: { docType?: string; items?: Array<Record<string, unknown>>; retention?: number },
+  ctx: z.RefinementCtx
+): void {
+  data.items?.forEach((item, index) => {
+    if (item && typeof item === 'object' && 'account' in item) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['items', index, 'account'],
+        message:
+          'Holded silently ignores `account` on document line items. Set the account at document level via `expAccountId`, which cascades to every line.',
+      });
+    }
+  });
+  if (data.retention !== undefined && data.docType && PURCHASE_DOC_TYPES.has(data.docType)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['retention'],
+      message:
+        'Holded ignores `retention` (IRPF) on purchase documents — it can only be set in the Holded UI. Remove it to avoid a false success, then set the retention manually.',
+    });
+  }
+}
+
+export const createDocumentSchema = z
+  .object({
+    docType: docTypeEnum,
+    contactId: z.string().min(1),
+    items: z.array(documentItemSchema),
     /**
-     * Document date as Unix timestamp (integer).
-     * Required by the Holded API when updating the date field.
+     * Document date as Unix timestamp (integer). Required by the Holded API.
+     * If omitted, Holded will reject the request. Use Math.floor(Date.now() / 1000)
+     * to get the current timestamp.
      */
-    date: z.number().int().optional(),
+    date: z.number().int(),
     notes: z.string().optional(),
     currency: z.string().optional(),
     /** Document reference number (e.g. invoice number from supplier) */
@@ -241,8 +263,51 @@ export const updateDocumentSchema = documentIdSchema.merge(
     salesChannelId: z.string().optional(),
     /** Expense account ID for expense documents */
     expAccountId: z.string().optional(),
+    /**
+     * Retention (IRPF) percentage. Valid on sales documents; rejected on
+     * purchases, where Holded ignores it (UI-only). See {@link assertDocumentWriteSafety}.
+     */
+    retention: z.number().optional(),
+    /**
+     * Whether to immediately approve (finalize) the document instead of saving it as a draft.
+     *
+     * Defaults to `true` so created documents are visible in the Holded UI by default. When
+     * omitted, the Holded API itself defaults to `false` (draft), and drafts are hidden from
+     * the standard Sales > Invoices list, the contact's Sales tab and global search — they
+     * exist but are not reachable from the UI.
+     *
+     * Pass `false` explicitly only when you intentionally want a draft for later review.
+     *
+     * Note: once a document is approved it is permanently locked by Holded and cannot be
+     * deleted or freely edited.
+     */
+    approveDoc: z.boolean().optional(),
   })
-);
+  .superRefine(assertDocumentWriteSafety);
+
+export const updateDocumentSchema = documentIdSchema
+  .merge(
+    z.object({
+      contactId: z.string().optional(),
+      items: z.array(documentItemSchema).optional(),
+      /**
+       * Document date as Unix timestamp (integer).
+       * Required by the Holded API when updating the date field.
+       */
+      date: z.number().int().optional(),
+      notes: z.string().optional(),
+      currency: z.string().optional(),
+      /** Document reference number (e.g. invoice number from supplier) */
+      invoiceNum: z.string().optional(),
+      /** Sales channel ID to associate with the document */
+      salesChannelId: z.string().optional(),
+      /** Expense account ID for expense documents */
+      expAccountId: z.string().optional(),
+      /** Retention (IRPF) percentage. Rejected on purchases (see create). */
+      retention: z.number().optional(),
+    })
+  )
+  .superRefine(assertDocumentWriteSafety);
 
 // Product schemas
 export const productIdSchema = z.object({
@@ -333,7 +398,22 @@ export const createPaymentSchema = z.object({
   days: z.number().int().nonnegative().optional(),
 });
 
-export const updatePaymentSchema = paymentIdSchema.merge(createPaymentSchema.partial());
+export const updatePaymentSchema = paymentIdSchema.merge(createPaymentSchema.partial()).merge(
+  z.object({
+    /**
+     * Bank/treasury account id to link the payment to. `PUT /payments/{id}` is
+     * how a payment gets associated with a bank (the `/pay` endpoint can't do
+     * it). See EXTENSIONS.md #8.
+     */
+    bankId: z.string().optional(),
+    /** Contact id. Re-sent on update because PUT /payments REPLACES the record. */
+    contactId: z.string().optional(),
+    /** Payment date as a Unix timestamp (seconds). */
+    date: z.number().int().optional(),
+    /** Payment amount. */
+    amount: z.number().optional(),
+  })
+);
 
 // Numbering series schemas
 export const numberingSerieIdSchema = z.object({
@@ -351,6 +431,88 @@ export const createNumberingSerieSchema = z.object({
 export const updateNumberingSerieSchema = numberingSerieIdSchema.merge(
   createNumberingSerieSchema.partial().omit({ docType: true })
 );
+
+// Time-tracking (Projects API) schemas
+//
+// The Projects API returns dates as Unix timestamps (seconds, local midnight)
+// and durations in seconds. The optional date filters below accept `YYYY-MM-DD`
+// strings so callers don't have to compute timestamps themselves; the tool layer
+// converts them when comparing against each entry's `date`.
+
+/** ISO calendar date in `YYYY-MM-DD` form (e.g. `2026-03-31`). */
+const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format');
+
+export const listProjectTimesSchema = z.object({
+  /** Restrict results to entries on or after this date (inclusive). */
+  startDate: isoDateSchema.optional(),
+  /** Restrict results to entries on or before this date (inclusive). */
+  endDate: isoDateSchema.optional(),
+  /** When true, keep only approved entries (`approved === 1`). */
+  approvedOnly: z.boolean().optional(),
+  /**
+   * When true, return a flat array of time entries (each enriched with its
+   * project id/name) instead of the nested per-project structure. Convenient
+   * for summing hours across a month.
+   */
+  flatten: z.boolean().optional(),
+});
+
+export const projectTimesSchema = z
+  .object({
+    projectId: z.string().min(1),
+  })
+  .merge(listProjectTimesSchema);
+
+export const projectTimeIdSchema = z.object({
+  projectId: z.string().min(1),
+  timeTrackingId: z.string().min(1),
+});
+
+// Accounting (read-only) schemas
+//
+// The accounting API works in Unix-second timestamps. The daily ledger rejects
+// ranges longer than one year server-side (HTTP 400 "Maximum 1 year between
+// start and end"); we validate that client-side to fail fast with a clear error.
+
+/** Maximum span the daily-ledger endpoint accepts, in seconds (~1 leap year). */
+const MAX_LEDGER_RANGE_SECONDS = 366 * 24 * 60 * 60;
+
+export const dailyLedgerSchema = z
+  .object({
+    /** Range start as a Unix timestamp (seconds). */
+    starttmp: z.number().int().nonnegative(),
+    /** Range end as a Unix timestamp (seconds). */
+    endtmp: z.number().int().nonnegative(),
+    /**
+     * When true, group ledger lines by `entryNumber` so each returned object is
+     * a full double-entry journal entry (asiento) with its lines nested.
+     */
+    groupByEntry: z.boolean().optional(),
+  })
+  .refine((v) => v.endtmp >= v.starttmp, {
+    message: 'endtmp must be greater than or equal to starttmp',
+    path: ['endtmp'],
+  })
+  .refine((v) => v.endtmp - v.starttmp <= MAX_LEDGER_RANGE_SECONDS, {
+    message: 'Date range must not exceed 1 year (Holded rejects longer spans)',
+    path: ['endtmp'],
+  });
+
+// Banking (EXPERIMENTAL — undocumented internal API) schemas
+//
+// Bank-feed reconciliation lives on Holded's internal API
+// (`/internal/banking/...`), which is not part of the public contract. These
+// schemas exist so the experimental tool validates its identifiers, but the
+// endpoint itself is unverified — see `src/tools/banking.ts`.
+
+export const reconcileBankTransactionSchema = z.object({
+  /** Holded bank account id (the bank-feed account, not a treasury id). */
+  accountId: z.string().min(1),
+  /** Bank-feed transaction id to reconcile. */
+  transactionId: z.string().min(1),
+  /** Optional accounting entry / document id to match the transaction against. */
+  entryId: z.string().min(1).optional(),
+});
 
 /**
  * Validation utility function

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -176,14 +176,14 @@ export const payDocumentSchema = z.object({
   /**
    * Payment-method catalog id (the `/paymentmethods` id), NOT a bank/treasury id.
    * Holded's `/pay` endpoint treats the payment method and the bank link as two
-   * separate things — see `bankId`. (EXTENSIONS.md #8.)
+   * separate things — see `bankId`.
    */
   paymentmethod: z.string().optional(),
   /**
    * Bank/treasury account id to associate the resulting payment with. The `/pay`
    * endpoint does NOT accept this; the bank link can only be set via
    * `PUT /payments/{id}` afterwards, so `pay_document` performs that second step
-   * when this is provided. (EXTENSIONS.md #8.)
+   * when this is provided.
    */
   bankId: z.string().optional(),
 });
@@ -403,7 +403,7 @@ export const updatePaymentSchema = paymentIdSchema.merge(createPaymentSchema.par
     /**
      * Bank/treasury account id to link the payment to. `PUT /payments/{id}` is
      * how a payment gets associated with a bank (the `/pay` endpoint can't do
-     * it). See EXTENSIONS.md #8.
+     * it).
      */
     bankId: z.string().optional(),
     /** Contact id. Re-sent on update because PUT /payments REPLACES the record. */


### PR DESCRIPTION
## What

Hardens the document and payment write tools against Holded's "silent-fail"
behavior, where the API returns a success (`{"status":1,...}`) even when it
ignored part of the payload.

Two complementary mechanisms:

1. **Up-front guards** (`validation.ts`) reject writes that Holded would silently
   drop, so the caller gets a clear error instead of a false success:
   - a line-level `account` (the expense/income account must be set at document
     level via `expAccountId`, which cascades to the lines);
   - `retention` (IRPF) on a *purchase* document — there is no API to set it on
     purchases, so accepting it would report success for a no-op.

2. **Read-back warnings.** After a write, the tool re-reads the record and, if
   Holded quietly overrode the request, attaches a non-fatal `_warnings[]` array
   to the result — e.g. a numbering series overriding the requested `invoiceNum`,
   a currency change that didn't persist, or a document auto-approved as a side
   effect of being paid. The result then reflects what Holded actually stored.

Also adds `get_document_payments` (read the payments registered against a
document) and integrates with the recently-merged `approveDoc` default.

## Why

Holded's write endpoints don't tell you when they ignore a field, so an assistant
can confidently report "done — invoice number set to X" when Holded assigned a
different number from a numbering series. That's a quietly wrong answer with real
bookkeeping consequences. Failing fast on known-ignored fields, and otherwise
reporting what was actually persisted, makes the write tools trustworthy.

## Changes

- `src/validation.ts` — `PURCHASE_DOC_TYPES`, `assertDocumentWriteSafety`
  cross-field refinement on create/update document schemas.
- `src/tools/documents.ts` — read-back `_warnings` on create/update; `get_document_payments`.
- `src/tools/payments.ts`, `src/tools/treasuries.ts` — warning plumbing.
- Tests for the guards and warnings; README write-safety note + example.

The second commit removes references to an internal planning note that isn't part
of this repo (comment/test-label cleanup only — no behavior change).