### PR TITLE
feat(banking): add experimental bank-feed reconciliation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,15 @@ This MCP server provides access to the complete Holded Invoice API:
 - **Services** (5 tools): Manage services.
 - **Time Tracking** (3 tools, read-only): Read project time entries from the Projects API (list all, list by project, get one), with optional flattening that adds `hours` for reporting.
 - **Accounting** (2 tools, read-only): Daily ledger (journal) and full chart of accounts from the Accounting API.
+- **Banking** (1 tool, ⚠️ experimental): Reconcile a bank-feed transaction via Holded's **undocumented internal API**. Not part of the public contract and may break without notice — see the note below.
 
-**Total: 77 tools**
+**Total: 78 tools**
+
+> **⚠️ Experimental — Banking tool:** `reconcile_bank_transaction` targets
+> Holded's internal banking API (`/internal/banking/...`), which is **not
+> documented or supported** by Holded. It has not been verified against a live
+> account, may change or break without notice, and always returns a
+> `_warnings` array flagging its experimental status. Use at your own risk.
 
 ## Installation
 
@@ -168,6 +175,7 @@ internal `apiGroup` selector; the invoicing base remains the default:
 https://api.holded.com/api/invoicing/v1/    # documents, contacts, products, treasury, … (default)
 https://api.holded.com/api/projects/v1/     # projects & time tracking
 https://api.holded.com/api/accounting/v1/   # chart of accounts & daily ledger (read-only)
+https://api.holded.com/api/internal/...     # ⚠️ undocumented internal API (experimental banking only)
 ```
 
 ### Authentication

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ This MCP server provides access to the complete Holded Invoice API:
 - **Contact Groups** (5 tools): Organize contacts into groups.
 - **Remittances** (2 tools): Access remittance data.
 - **Services** (5 tools): Manage services.
+- **Time Tracking** (3 tools, read-only): Read project time entries from the Projects API (list all, list by project, get one), with optional flattening that adds `hours` for reporting.
+- **Accounting** (2 tools, read-only): Daily ledger (journal) and full chart of accounts from the Accounting API.
 
-**Total: 72 tools**
+**Total: 77 tools**
 
 ## Installation
 
@@ -127,6 +129,16 @@ Once configured, you can ask Claude to:
 - "List all treasuries"
 - "Show me the sales channels"
 
+### Time Tracking
+
+- "List my approved time entries for March 2026"
+- "How many hours did I track on project X last month?"
+
+### Accounting
+
+- "Show me the daily ledger between two dates"
+- "Get the full chart of accounts"
+
 ## Document Types
 
 The API supports these document types:
@@ -147,10 +159,15 @@ The API supports these document types:
 
 ## API Reference
 
-### Base URL
+### Base URLs
+
+Holded exposes several independent APIs. Each tool targets the right one via an
+internal `apiGroup` selector; the invoicing base remains the default:
 
 ```
-https://api.holded.com/api/invoicing/v1/
+https://api.holded.com/api/invoicing/v1/    # documents, contacts, products, treasury, … (default)
+https://api.holded.com/api/projects/v1/     # projects & time tracking
+https://api.holded.com/api/accounting/v1/   # chart of accounts & daily ledger (read-only)
 ```
 
 ### Authentication

--- a/src/__tests__/accounting.test.ts
+++ b/src/__tests__/accounting.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createMockClient } from './mock-client.js';
+import { getAccountingTools } from '../tools/accounting.js';
+
+describe('Accounting Tools', () => {
+  let client: ReturnType<typeof createMockClient>;
+  let tools: ReturnType<typeof getAccountingTools>;
+
+  const start = Math.floor(new Date('2025-01-01T00:00:00Z').getTime() / 1000);
+  const end = Math.floor(new Date('2025-12-31T23:59:59Z').getTime() / 1000);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = createMockClient();
+    tools = getAccountingTools(client);
+  });
+
+  describe('get_chart_of_accounts', () => {
+    it('targets the accounting API base', async () => {
+      await tools.get_chart_of_accounts.handler();
+      expect(client.get).toHaveBeenCalledWith('/chartofaccounts', undefined, 'accounting');
+    });
+  });
+
+  describe('get_daily_ledger', () => {
+    it('requests the ledger on the accounting API with the timestamp range', async () => {
+      await tools.get_daily_ledger.handler({ starttmp: start, endtmp: end });
+      expect(client.get).toHaveBeenCalledWith(
+        '/dailyledger',
+        { starttmp: start, endtmp: end },
+        'accounting'
+      );
+    });
+
+    it('rejects a range longer than one year', async () => {
+      const tooLong = start + 400 * 24 * 60 * 60;
+      await expect(
+        tools.get_daily_ledger.handler({ starttmp: start, endtmp: tooLong })
+      ).rejects.toThrow(/1 year/);
+    });
+
+    it('rejects an inverted range', async () => {
+      await expect(
+        tools.get_daily_ledger.handler({ starttmp: end, endtmp: start })
+      ).rejects.toThrow(/greater than or equal/);
+    });
+
+    it('groups lines by entryNumber when requested', async () => {
+      vi.mocked(client.get).mockResolvedValueOnce([
+        { entryNumber: 61, line: 1, type: 'payment', account: 40000018, debit: 11.92, credit: 0 },
+        { entryNumber: 61, line: 2, type: 'payment', account: 57200000, debit: 0, credit: 11.92 },
+        { entryNumber: 62, line: 1, type: 'purchase', account: 60000000, debit: 50, credit: 0 },
+      ]);
+      const result = (await tools.get_daily_ledger.handler({
+        starttmp: start,
+        endtmp: end,
+        groupByEntry: true,
+      })) as Array<{
+        entryNumber: number;
+        lines: unknown[];
+        totalDebit: number;
+        totalCredit: number;
+      }>;
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ entryNumber: 61, totalDebit: 11.92, totalCredit: 11.92 });
+      expect(result[0].lines).toHaveLength(2);
+      expect(result[1]).toMatchObject({ entryNumber: 62, totalDebit: 50, totalCredit: 0 });
+    });
+  });
+});

--- a/src/__tests__/banking.test.ts
+++ b/src/__tests__/banking.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createMockClient } from './mock-client.js';
+import { getBankingTools } from '../tools/banking.js';
+
+describe('Banking Tools (EXPERIMENTAL — internal API)', () => {
+  let client: ReturnType<typeof createMockClient>;
+  let tools: ReturnType<typeof getBankingTools>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = createMockClient();
+    tools = getBankingTools(client);
+  });
+
+  describe('reconcile_bank_transaction', () => {
+    it('posts to the internal reconcile endpoint on the `internal` API base', async () => {
+      client.post = vi.fn().mockResolvedValue({ status: 1 });
+      await tools.reconcile_bank_transaction.handler({
+        accountId: 'acc-1',
+        transactionId: 'txn-1',
+        entryId: 'entry-1',
+      });
+      expect(client.post).toHaveBeenCalledWith(
+        '/internal/banking/accounts/acc-1/transactions/txn-1/reconcile',
+        { entryId: 'entry-1' },
+        'internal'
+      );
+    });
+
+    it('always returns an experimental/unverified warning', async () => {
+      client.post = vi.fn().mockResolvedValue({ status: 1 });
+      const result = (await tools.reconcile_bank_transaction.handler({
+        accountId: 'acc-1',
+        transactionId: 'txn-1',
+      })) as any;
+      expect(result._warnings).toBeDefined();
+      expect(result._warnings[0]).toMatch(/undocumented|unverified/i);
+    });
+
+    it('rejects when required identifiers are missing', async () => {
+      await expect(
+        tools.reconcile_bank_transaction.handler({ accountId: '', transactionId: 'txn-1' } as any)
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/__tests__/time-tracking.test.ts
+++ b/src/__tests__/time-tracking.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createMockClient } from './mock-client.js';
+import { getTimeTrackingTools, unixToLocalISODate } from '../tools/time-tracking.js';
+
+// Unix timestamp for local midnight on 2026-06-02 in the test host's timezone.
+function localMidnightUnix(year: number, month: number, day: number): number {
+  return Math.floor(new Date(year, month - 1, day).getTime() / 1000);
+}
+
+describe('Time Tracking Tools', () => {
+  let client: ReturnType<typeof createMockClient>;
+  let tools: ReturnType<typeof getTimeTrackingTools>;
+
+  const day1 = localMidnightUnix(2026, 6, 1);
+  const day2 = localMidnightUnix(2026, 6, 2);
+  const day3 = localMidnightUnix(2026, 6, 3);
+
+  const sampleProjects = [
+    {
+      id: 'project-1',
+      name: 'SAP',
+      timeTracking: [
+        { timeId: 't1', duration: 28800, date: day1, approved: 1 },
+        { timeId: 't2', duration: 28800, date: day2, approved: 0 },
+        { timeId: 't3', duration: 9000, date: day3, approved: 1 },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = createMockClient();
+    tools = getTimeTrackingTools(client);
+  });
+
+  describe('list_project_times', () => {
+    it('targets the projects API base, not invoicing', async () => {
+      await tools.list_project_times.handler({});
+      expect(client.get).toHaveBeenCalledWith('/projects/times', undefined, 'projects');
+    });
+
+    it('returns the nested per-project structure unchanged when no filters given', async () => {
+      vi.mocked(client.get).mockResolvedValueOnce(sampleProjects);
+      const result = (await tools.list_project_times.handler({})) as typeof sampleProjects;
+      expect(result[0].timeTracking).toHaveLength(3);
+    });
+
+    it('keeps only approved entries when approvedOnly is set', async () => {
+      vi.mocked(client.get).mockResolvedValueOnce(sampleProjects);
+      const result = (await tools.list_project_times.handler({
+        approvedOnly: true,
+      })) as typeof sampleProjects;
+      expect(result[0].timeTracking.map((e) => e.timeId)).toEqual(['t1', 't3']);
+    });
+
+    it('filters by inclusive date range', async () => {
+      vi.mocked(client.get).mockResolvedValueOnce(sampleProjects);
+      const result = (await tools.list_project_times.handler({
+        startDate: '2026-06-02',
+        endDate: '2026-06-02',
+      })) as typeof sampleProjects;
+      expect(result[0].timeTracking.map((e) => e.timeId)).toEqual(['t2']);
+    });
+
+    it('flattens entries and computes hours', async () => {
+      vi.mocked(client.get).mockResolvedValueOnce(sampleProjects);
+      const result = (await tools.list_project_times.handler({
+        flatten: true,
+        approvedOnly: true,
+      })) as Array<{ timeId: string; hours: number; projectName: string }>;
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ timeId: 't1', hours: 8, projectName: 'SAP' });
+      expect(result[1]).toMatchObject({ timeId: 't3', hours: 2.5 });
+    });
+  });
+
+  describe('list_project_times_by_project', () => {
+    it('requests the project-scoped endpoint on the projects API', async () => {
+      vi.mocked(client.get).mockResolvedValueOnce(sampleProjects[0]);
+      await tools.list_project_times_by_project.handler({ projectId: 'project-1' });
+      expect(client.get).toHaveBeenCalledWith('/projects/project-1/times', undefined, 'projects');
+    });
+
+    it('applies filters to a single project response', async () => {
+      vi.mocked(client.get).mockResolvedValueOnce(sampleProjects[0]);
+      const result = (await tools.list_project_times_by_project.handler({
+        projectId: 'project-1',
+        approvedOnly: true,
+      })) as Array<{ timeTracking: Array<{ timeId: string }> }>;
+      expect(result[0].timeTracking.map((e) => e.timeId)).toEqual(['t1', 't3']);
+    });
+  });
+
+  describe('get_project_time', () => {
+    it('requests a single entry on the projects API', async () => {
+      await tools.get_project_time.handler({
+        projectId: 'project-1',
+        timeTrackingId: 't1',
+      });
+      expect(client.get).toHaveBeenCalledWith(
+        '/projects/project-1/times/t1',
+        undefined,
+        'projects'
+      );
+    });
+  });
+
+  describe('unixToLocalISODate', () => {
+    it('formats a local-midnight timestamp to its calendar day', () => {
+      expect(unixToLocalISODate(day2)).toBe('2026-06-02');
+    });
+  });
+});

--- a/src/holded-client.ts
+++ b/src/holded-client.ts
@@ -11,11 +11,16 @@ import FormData from 'form-data';
  *   (`/projects/times`, `/projects/{id}/times/...`).
  * - `accounting` — the (read-only) accounting layer: chart of accounts and the
  *   daily ledger / journal (`/chartofaccounts`, `/dailyledger`).
+ * - `internal` — Holded's UNDOCUMENTED internal API (note: no `/v1` segment).
+ *   Currently used only for bank-feed reconciliation (`/internal/banking/...`).
+ *   These endpoints are NOT part of the public contract and may change or break
+ *   without notice; treat tools built on them as experimental and unverified.
  */
 const API_BASES = {
   invoicing: 'https://api.holded.com/api/invoicing/v1',
   projects: 'https://api.holded.com/api/projects/v1',
   accounting: 'https://api.holded.com/api/accounting/v1',
+  internal: 'https://api.holded.com/api',
 } as const;
 
 export type ApiGroup = keyof typeof API_BASES;

--- a/src/holded-client.ts
+++ b/src/holded-client.ts
@@ -1,7 +1,26 @@
 import fetch, { RequestInit } from 'node-fetch';
 import FormData from 'form-data';
 
-const BASE_URL = 'https://api.holded.com/api/invoicing/v1';
+/**
+ * Holded exposes several independent REST APIs, each under its own base path.
+ * Tools select which one they target via the `apiGroup` parameter.
+ *
+ * - `invoicing` — documents, contacts, products, treasury, etc. (the default,
+ *   for backward compatibility with every existing tool).
+ * - `projects` — projects and time tracking
+ *   (`/projects/times`, `/projects/{id}/times/...`).
+ * - `accounting` — the (read-only) accounting layer: chart of accounts and the
+ *   daily ledger / journal (`/chartofaccounts`, `/dailyledger`).
+ */
+const API_BASES = {
+  invoicing: 'https://api.holded.com/api/invoicing/v1',
+  projects: 'https://api.holded.com/api/projects/v1',
+  accounting: 'https://api.holded.com/api/accounting/v1',
+} as const;
+
+export type ApiGroup = keyof typeof API_BASES;
+
+const DEFAULT_API_GROUP: ApiGroup = 'invoicing';
 
 export class HoldedClient {
   private apiKey: string;
@@ -21,9 +40,10 @@ export class HoldedClient {
     method: string,
     endpoint: string,
     body?: unknown,
-    queryParams?: Record<string, string | number>
+    queryParams?: Record<string, string | number>,
+    apiGroup: ApiGroup = DEFAULT_API_GROUP
   ): Promise<T> {
-    let url = `${BASE_URL}${endpoint}`;
+    let url = `${API_BASES[apiGroup]}${endpoint}`;
 
     if (queryParams) {
       const params = new URLSearchParams();
@@ -115,25 +135,37 @@ export class HoldedClient {
     throw lastError || new Error('Request failed after retries');
   }
 
-  async get<T>(endpoint: string, queryParams?: Record<string, string | number>): Promise<T> {
-    return this.request<T>('GET', endpoint, undefined, queryParams);
+  async get<T>(
+    endpoint: string,
+    queryParams?: Record<string, string | number>,
+    apiGroup: ApiGroup = DEFAULT_API_GROUP
+  ): Promise<T> {
+    return this.request<T>('GET', endpoint, undefined, queryParams, apiGroup);
   }
 
-  async post<T>(endpoint: string, body?: unknown): Promise<T> {
-    return this.request<T>('POST', endpoint, body);
+  async post<T>(
+    endpoint: string,
+    body?: unknown,
+    apiGroup: ApiGroup = DEFAULT_API_GROUP
+  ): Promise<T> {
+    return this.request<T>('POST', endpoint, body, undefined, apiGroup);
   }
 
-  async put<T>(endpoint: string, body?: unknown): Promise<T> {
-    return this.request<T>('PUT', endpoint, body);
+  async put<T>(
+    endpoint: string,
+    body?: unknown,
+    apiGroup: ApiGroup = DEFAULT_API_GROUP
+  ): Promise<T> {
+    return this.request<T>('PUT', endpoint, body, undefined, apiGroup);
   }
 
-  async delete<T>(endpoint: string): Promise<T> {
-    return this.request<T>('DELETE', endpoint);
+  async delete<T>(endpoint: string, apiGroup: ApiGroup = DEFAULT_API_GROUP): Promise<T> {
+    return this.request<T>('DELETE', endpoint, undefined, undefined, apiGroup);
   }
 
   // File upload for attachments with retry logic
   async uploadFile(endpoint: string, file: Buffer, filename: string): Promise<unknown> {
-    const url = `${BASE_URL}${endpoint}`;
+    const url = `${API_BASES[DEFAULT_API_GROUP]}${endpoint}`;
     let lastError: Error | null = null;
 
     // Retry loop with exponential backoff

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ import { getContactGroupTools } from './tools/contact-groups.js';
 import { getRemittanceTools } from './tools/remittances.js';
 import { getServiceTools } from './tools/services.js';
 import { getWarehouseTools } from './tools/warehouses.js';
+import { getTimeTrackingTools } from './tools/time-tracking.js';
+import { getAccountingTools } from './tools/accounting.js';
 
 // Initialize multi-tenancy support
 const tenantConfigs = loadTenantConfigs();
@@ -73,6 +75,8 @@ const allTools = {
   ...getRemittanceTools(client),
   ...getServiceTools(client),
   ...getWarehouseTools(client),
+  ...getTimeTrackingTools(client),
+  ...getAccountingTools(client),
 };
 
 // Create server
@@ -157,6 +161,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     ...getRemittanceTools(tenantContext.client),
     ...getServiceTools(tenantContext.client),
     ...getWarehouseTools(tenantContext.client),
+    ...getTimeTrackingTools(tenantContext.client),
+    ...getAccountingTools(tenantContext.client),
   };
 
   const tool = tenantTools[name as keyof typeof tenantTools];

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { getServiceTools } from './tools/services.js';
 import { getWarehouseTools } from './tools/warehouses.js';
 import { getTimeTrackingTools } from './tools/time-tracking.js';
 import { getAccountingTools } from './tools/accounting.js';
+import { getBankingTools } from './tools/banking.js';
 
 // Initialize multi-tenancy support
 const tenantConfigs = loadTenantConfigs();
@@ -77,6 +78,7 @@ const allTools = {
   ...getWarehouseTools(client),
   ...getTimeTrackingTools(client),
   ...getAccountingTools(client),
+  ...getBankingTools(client),
 };
 
 // Create server
@@ -163,6 +165,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     ...getWarehouseTools(tenantContext.client),
     ...getTimeTrackingTools(tenantContext.client),
     ...getAccountingTools(tenantContext.client),
+    ...getBankingTools(tenantContext.client),
   };
 
   const tool = tenantTools[name as keyof typeof tenantTools];

--- a/src/tools/accounting.ts
+++ b/src/tools/accounting.ts
@@ -1,0 +1,123 @@
+import { HoldedClient } from '../holded-client.js';
+import { dailyLedgerSchema, withValidation } from '../validation.js';
+
+/**
+ * Read-only tools backed by the Holded **Accounting** API
+ * (`https://api.holded.com/api/accounting/v1`).
+ *
+ * The accounting layer is the authoritative source for balance-sheet / annual
+ * accounts figures: the document (invoicing) layer is decoupled from it. The
+ * API is read-only — Holded exposes no endpoint to create/edit/delete manual
+ * journal entries (asientos) — so no mutating tools are provided here.
+ */
+
+/** A single line of the daily ledger as returned by the Accounting API. */
+interface LedgerLine extends Record<string, unknown> {
+  entryNumber?: number;
+  line?: number;
+  timestamp?: number;
+  type?: string;
+  description?: string;
+  account?: number;
+  debit?: number;
+  credit?: number;
+}
+
+/** A grouped journal entry: all lines that share an `entryNumber`. */
+interface LedgerEntry {
+  entryNumber?: number;
+  timestamp?: number;
+  type?: string;
+  description?: string;
+  lines: LedgerLine[];
+  totalDebit: number;
+  totalCredit: number;
+}
+
+/**
+ * Group flat ledger lines into double-entry journal entries keyed by
+ * `entryNumber`, preserving first-seen order and summing debit/credit so each
+ * entry can be checked for balance.
+ *
+ * @param lines - Flat ledger lines from `/dailyledger`.
+ * @returns One {@link LedgerEntry} per distinct `entryNumber`.
+ */
+function groupLedgerByEntry(lines: LedgerLine[]): LedgerEntry[] {
+  const byEntry = new Map<number | string, LedgerEntry>();
+  for (const line of lines) {
+    const key = line.entryNumber ?? `__ungrouped_${byEntry.size}`;
+    let entry = byEntry.get(key);
+    if (!entry) {
+      entry = {
+        entryNumber: line.entryNumber,
+        timestamp: line.timestamp,
+        type: line.type,
+        description: line.description,
+        lines: [],
+        totalDebit: 0,
+        totalCredit: 0,
+      };
+      byEntry.set(key, entry);
+    }
+    entry.lines.push(line);
+    entry.totalDebit += line.debit ?? 0;
+    entry.totalCredit += line.credit ?? 0;
+  }
+  return Array.from(byEntry.values());
+}
+
+export function getAccountingTools(client: HoldedClient) {
+  return {
+    // Chart of accounts (active fiscal year)
+    get_chart_of_accounts: {
+      description:
+        'Get the full chart of accounts for the ACTIVE fiscal year (Accounting API). Returns every account with `num` (PGC number, e.g. 40000000), `name`, `group`, `debit`, `credit`, and `balance`. Unlike list_expenses_accounts (group-6 only), this includes all groups (assets, liabilities, income, expenses). Read-only.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {},
+        required: [],
+      },
+      readOnlyHint: true,
+      handler: async () => {
+        return client.get('/chartofaccounts', undefined, 'accounting');
+      },
+    },
+
+    // Daily ledger / journal
+    get_daily_ledger: {
+      description:
+        'Get the daily ledger (journal / asientos) between two Unix timestamps (Accounting API). Returns one row per ledger line with entryNumber, line, timestamp, type (collect/payment/purchase/...), description, account (PGC num), debit, and credit. This is the authoritative source for balance-sheet and tax-return figures. Range must not exceed 1 year. Set groupByEntry to nest lines into full double-entry entries with per-entry debit/credit totals. Read-only.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          starttmp: {
+            type: 'number',
+            description: 'Range start as a Unix timestamp in seconds (inclusive)',
+          },
+          endtmp: {
+            type: 'number',
+            description: 'Range end as a Unix timestamp in seconds (inclusive)',
+          },
+          groupByEntry: {
+            type: 'boolean',
+            description:
+              'Group lines by entryNumber into full journal entries (each with totalDebit/totalCredit). Default: false (flat lines)',
+          },
+        },
+        required: ['starttmp', 'endtmp'],
+      },
+      readOnlyHint: true,
+      handler: withValidation(dailyLedgerSchema, async (args) => {
+        const lines = (await client.get(
+          '/dailyledger',
+          { starttmp: args.starttmp, endtmp: args.endtmp },
+          'accounting'
+        )) as LedgerLine[];
+        if (args.groupByEntry) {
+          return groupLedgerByEntry(lines);
+        }
+        return lines;
+      }),
+    },
+  };
+}

--- a/src/tools/banking.ts
+++ b/src/tools/banking.ts
@@ -1,0 +1,55 @@
+import { HoldedClient } from '../holded-client.js';
+import { reconcileBankTransactionSchema, withValidation } from '../validation.js';
+
+/**
+ * EXPERIMENTAL bank-feed tools backed by Holded's UNDOCUMENTED internal API
+ * (`https://api.holded.com/api/internal/banking/...`).
+ *
+ * These endpoints are not part of Holded's public, versioned API. They have not
+ * been verified against a live account in this fork, the exact request/response
+ * shapes are not guaranteed, and Holded may change or remove them without
+ * notice. Every tool here is marked clearly as experimental and returns a
+ * `_warnings` note so callers always double-check the result in the Holded UI.
+ */
+export function getBankingTools(client: HoldedClient) {
+  return {
+    // Reconcile a bank-feed transaction (EXPERIMENTAL — internal API)
+    reconcile_bank_transaction: {
+      description:
+        "EXPERIMENTAL / UNVERIFIED. Reconcile (match) a single bank-feed transaction against its accounting entry via Holded's UNDOCUMENTED internal API (POST /internal/banking/accounts/{accountId}/transactions/{transactionId}/reconcile). This endpoint is NOT part of the public API, has not been verified against a live account, and may change or fail without notice. Always re-check the reconciliation in the Holded UI afterwards.",
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          accountId: {
+            type: 'string',
+            description: 'Holded bank account id (the bank-feed account, not a treasury id)',
+          },
+          transactionId: {
+            type: 'string',
+            description: 'Bank-feed transaction id to reconcile',
+          },
+          entryId: {
+            type: 'string',
+            description: 'Optional accounting entry / document id to match the transaction against',
+          },
+        },
+        required: ['accountId', 'transactionId'],
+      },
+      destructiveHint: true,
+      handler: withValidation(reconcileBankTransactionSchema, async (args) => {
+        const { accountId, transactionId, ...body } = args;
+        const result = await client.post(
+          `/internal/banking/accounts/${accountId}/transactions/${transactionId}/reconcile`,
+          body,
+          'internal'
+        );
+        const warning =
+          'reconcile_bank_transaction uses an undocumented internal Holded endpoint and is unverified. Confirm the reconciliation in the Holded UI.';
+        if (result && typeof result === 'object' && !Array.isArray(result)) {
+          return { ...(result as object), _warnings: [warning] };
+        }
+        return { result, _warnings: [warning] };
+      }),
+    },
+  };
+}

--- a/src/tools/time-tracking.ts
+++ b/src/tools/time-tracking.ts
@@ -1,0 +1,239 @@
+import { HoldedClient } from '../holded-client.js';
+import {
+  listProjectTimesSchema,
+  projectTimesSchema,
+  projectTimeIdSchema,
+  withValidation,
+} from '../validation.js';
+
+/**
+ * Time-tracking tools backed by the Holded **Projects** API
+ * (`https://api.holded.com/api/projects/v1`). These are read-only: they expose
+ * the hours logged in Holded so they can be reconciled or booked elsewhere
+ * (e.g. into an external time sheet). No mutating endpoints are provided.
+ */
+
+/** A single time-tracking entry as returned by the Holded Projects API. */
+interface HoldedTimeEntry extends Record<string, unknown> {
+  /** Duration of the entry in seconds. */
+  duration?: number;
+  /** Day of the entry as a Unix timestamp (seconds, local midnight). */
+  date?: number;
+  /** 1 when the entry has been approved, 0 otherwise. */
+  approved?: number;
+}
+
+/** A project with its nested time-tracking entries. */
+interface HoldedProjectTimes extends Record<string, unknown> {
+  id?: string;
+  name?: string;
+  timeTracking?: HoldedTimeEntry[];
+}
+
+/** A flattened entry: the raw entry plus the project it belongs to. */
+type FlattenedTimeEntry = HoldedTimeEntry & {
+  projectId?: string;
+  projectName?: string;
+  /** Convenience: `duration` expressed in hours (`duration / 3600`). */
+  hours?: number;
+};
+
+/**
+ * Format a Unix timestamp (seconds) as a `YYYY-MM-DD` calendar date using the
+ * host's local timezone.
+ *
+ * Holded stores each entry's `date` as **local midnight** expressed in Unix
+ * seconds. Because the MCP runs on the user's machine (same timezone the hours
+ * were logged in), local extraction reproduces the intended calendar day —
+ * whereas UTC extraction can be off by one near the date boundary.
+ *
+ * @param unixSeconds - Unix timestamp in seconds.
+ * @returns The calendar date as `YYYY-MM-DD`.
+ */
+export function unixToLocalISODate(unixSeconds: number): string {
+  const d = new Date(unixSeconds * 1000);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Decide whether a single time entry passes the optional client-side filters.
+ *
+ * @param entry - The time entry to test.
+ * @param filters - Optional `startDate`/`endDate` (inclusive, `YYYY-MM-DD`) and
+ *   `approvedOnly` flag.
+ * @returns `true` when the entry should be kept.
+ */
+function entryMatches(
+  entry: HoldedTimeEntry,
+  filters: { startDate?: string; endDate?: string; approvedOnly?: boolean }
+): boolean {
+  if (filters.approvedOnly && entry.approved !== 1) {
+    return false;
+  }
+  if ((filters.startDate || filters.endDate) && typeof entry.date === 'number') {
+    const entryDate = unixToLocalISODate(entry.date);
+    if (filters.startDate && entryDate < filters.startDate) {
+      return false;
+    }
+    if (filters.endDate && entryDate > filters.endDate) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Apply the optional filters to a list of projects, returning either the
+ * nested per-project structure (with non-matching entries removed) or a flat
+ * list of enriched entries.
+ *
+ * @param projects - Projects with their `timeTracking` arrays.
+ * @param args - Filter + shape options.
+ * @returns Filtered projects, or a flat entry array when `flatten` is set.
+ */
+function shapeProjectTimes(
+  projects: HoldedProjectTimes[],
+  args: { startDate?: string; endDate?: string; approvedOnly?: boolean; flatten?: boolean }
+): HoldedProjectTimes[] | FlattenedTimeEntry[] {
+  if (args.flatten) {
+    const flat: FlattenedTimeEntry[] = [];
+    for (const project of projects) {
+      for (const entry of project.timeTracking ?? []) {
+        if (entryMatches(entry, args)) {
+          flat.push({
+            ...entry,
+            projectId: project.id,
+            projectName: project.name,
+            hours: typeof entry.duration === 'number' ? entry.duration / 3600 : undefined,
+          });
+        }
+      }
+    }
+    return flat;
+  }
+
+  return projects.map((project) => ({
+    ...project,
+    timeTracking: (project.timeTracking ?? []).filter((entry) => entryMatches(entry, args)),
+  }));
+}
+
+export function getTimeTrackingTools(client: HoldedClient) {
+  return {
+    // List time tracking across all projects
+    list_project_times: {
+      description:
+        'List time-tracking entries across all Holded projects (Projects API). Each project includes a timeTracking[] array of entries with duration (seconds), date (Unix seconds), user, and approved (0/1). Optionally filter by date range (YYYY-MM-DD, inclusive) and approved-only, and flatten into a single entry list with hours pre-computed. Read-only.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          startDate: {
+            type: 'string',
+            description: 'Keep only entries on or after this date (YYYY-MM-DD, inclusive)',
+          },
+          endDate: {
+            type: 'string',
+            description: 'Keep only entries on or before this date (YYYY-MM-DD, inclusive)',
+          },
+          approvedOnly: {
+            type: 'boolean',
+            description: 'Keep only approved entries (approved === 1). Default: false',
+          },
+          flatten: {
+            type: 'boolean',
+            description:
+              'Return a flat array of entries (each with projectId, projectName, and hours = duration/3600) instead of the nested per-project structure. Default: false',
+          },
+        },
+        required: [],
+      },
+      readOnlyHint: true,
+      handler: withValidation(listProjectTimesSchema, async (args) => {
+        const projects = (await client.get(
+          '/projects/times',
+          undefined,
+          'projects'
+        )) as HoldedProjectTimes[];
+        return shapeProjectTimes(projects, args);
+      }),
+    },
+
+    // List time tracking for a single project
+    list_project_times_by_project: {
+      description:
+        "List time-tracking entries for a single Holded project (Projects API). Returns the project's timeTracking[] array. Supports the same date-range, approved-only, and flatten filters as list_project_times. Read-only.",
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          projectId: {
+            type: 'string',
+            description: 'The Holded project ID',
+          },
+          startDate: {
+            type: 'string',
+            description: 'Keep only entries on or after this date (YYYY-MM-DD, inclusive)',
+          },
+          endDate: {
+            type: 'string',
+            description: 'Keep only entries on or before this date (YYYY-MM-DD, inclusive)',
+          },
+          approvedOnly: {
+            type: 'boolean',
+            description: 'Keep only approved entries (approved === 1). Default: false',
+          },
+          flatten: {
+            type: 'boolean',
+            description:
+              'Return a flat array of entries (each with projectId, projectName, and hours = duration/3600) instead of the nested structure. Default: false',
+          },
+        },
+        required: ['projectId'],
+      },
+      readOnlyHint: true,
+      handler: withValidation(projectTimesSchema, async (args) => {
+        const { projectId, ...filters } = args;
+        const project = (await client.get(
+          `/projects/${projectId}/times`,
+          undefined,
+          'projects'
+        )) as HoldedProjectTimes;
+        // Normalize to the same shape as list_project_times for consistent filtering.
+        const normalized: HoldedProjectTimes = Array.isArray(project)
+          ? { id: projectId, timeTracking: project as unknown as HoldedTimeEntry[] }
+          : project;
+        return shapeProjectTimes([normalized], filters);
+      }),
+    },
+
+    // Get a single time-tracking entry
+    get_project_time: {
+      description:
+        'Get a single time-tracking entry by project ID and time-tracking ID (Projects API). Read-only.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          projectId: {
+            type: 'string',
+            description: 'The Holded project ID',
+          },
+          timeTrackingId: {
+            type: 'string',
+            description: 'The time-tracking entry ID (the entry timeId)',
+          },
+        },
+        required: ['projectId', 'timeTrackingId'],
+      },
+      readOnlyHint: true,
+      handler: withValidation(projectTimeIdSchema, async (args) => {
+        return client.get(
+          `/projects/${args.projectId}/times/${args.timeTrackingId}`,
+          undefined,
+          'projects'
+        );
+      }),
+    },
+  };
+}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -352,6 +352,72 @@ export const updateNumberingSerieSchema = numberingSerieIdSchema.merge(
   createNumberingSerieSchema.partial().omit({ docType: true })
 );
 
+// Time-tracking (Projects API) schemas
+//
+// The Projects API returns dates as Unix timestamps (seconds, local midnight)
+// and durations in seconds. The optional date filters below accept `YYYY-MM-DD`
+// strings so callers don't have to compute timestamps themselves; the tool layer
+// converts them when comparing against each entry's `date`.
+
+/** ISO calendar date in `YYYY-MM-DD` form (e.g. `2026-03-31`). */
+const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format');
+
+export const listProjectTimesSchema = z.object({
+  /** Restrict results to entries on or after this date (inclusive). */
+  startDate: isoDateSchema.optional(),
+  /** Restrict results to entries on or before this date (inclusive). */
+  endDate: isoDateSchema.optional(),
+  /** When true, keep only approved entries (`approved === 1`). */
+  approvedOnly: z.boolean().optional(),
+  /**
+   * When true, return a flat array of time entries (each enriched with its
+   * project id/name) instead of the nested per-project structure. Convenient
+   * for summing hours across a month.
+   */
+  flatten: z.boolean().optional(),
+});
+
+export const projectTimesSchema = z
+  .object({
+    projectId: z.string().min(1),
+  })
+  .merge(listProjectTimesSchema);
+
+export const projectTimeIdSchema = z.object({
+  projectId: z.string().min(1),
+  timeTrackingId: z.string().min(1),
+});
+
+// Accounting (read-only) schemas
+//
+// The accounting API works in Unix-second timestamps. The daily ledger rejects
+// ranges longer than one year server-side (HTTP 400 "Maximum 1 year between
+// start and end"); we validate that client-side to fail fast with a clear error.
+
+/** Maximum span the daily-ledger endpoint accepts, in seconds (~1 leap year). */
+const MAX_LEDGER_RANGE_SECONDS = 366 * 24 * 60 * 60;
+
+export const dailyLedgerSchema = z
+  .object({
+    /** Range start as a Unix timestamp (seconds). */
+    starttmp: z.number().int().nonnegative(),
+    /** Range end as a Unix timestamp (seconds). */
+    endtmp: z.number().int().nonnegative(),
+    /**
+     * When true, group ledger lines by `entryNumber` so each returned object is
+     * a full double-entry journal entry (asiento) with its lines nested.
+     */
+    groupByEntry: z.boolean().optional(),
+  })
+  .refine((v) => v.endtmp >= v.starttmp, {
+    message: 'endtmp must be greater than or equal to starttmp',
+    path: ['endtmp'],
+  })
+  .refine((v) => v.endtmp - v.starttmp <= MAX_LEDGER_RANGE_SECONDS, {
+    message: 'Date range must not exceed 1 year (Holded rejects longer spans)',
+    path: ['endtmp'],
+  });
+
 /**
  * Validation utility function
  */

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -418,6 +418,22 @@ export const dailyLedgerSchema = z
     path: ['endtmp'],
   });
 
+// Banking (EXPERIMENTAL — undocumented internal API) schemas
+//
+// Bank-feed reconciliation lives on Holded's internal API
+// (`/internal/banking/...`), which is not part of the public contract. These
+// schemas exist so the experimental tool validates its identifiers, but the
+// endpoint itself is unverified — see `src/tools/banking.ts`.
+
+export const reconcileBankTransactionSchema = z.object({
+  /** Holded bank account id (the bank-feed account, not a treasury id). */
+  accountId: z.string().min(1),
+  /** Bank-feed transaction id to reconcile. */
+  transactionId: z.string().min(1),
+  /** Optional accounting entry / document id to match the transaction against. */
+  entryId: z.string().min(1).optional(),
+});
+
 /**
  * Validation utility function
  */


### PR DESCRIPTION
## ⚠️ Experimental — uses an undocumented internal API

This adds `reconcile_bank_transaction`, which matches a bank-feed transaction
against an accounting entry by calling Holded's **internal** banking API
(`/internal/banking/accounts/{accountId}/transactions/{transactionId}/reconcile`).

That endpoint is **not part of Holded's public, documented contract**. It has not
been verified against a live account and may change or break without notice. To
keep the risk explicit:

- the tool **always** returns a `_warnings[]` array flagging its experimental,
  unverified status;
- the README documents it under a dedicated warning block;
- a new `internal` API base (note: no `/v1` segment) is threaded through
  `HoldedClient` so it stays isolated from the supported invoicing / projects /
  accounting bases.

## Why

Bank reconciliation is otherwise a manual, UI-only step in Holded with no public
API. Exposing it — with loud caveats — lets an assistant close the loop after
registering a payment, while making the "this is unofficial and may break" risk
impossible to miss. It's deliberately shipped as opt-in/experimental rather than
presented as a stable feature.

## Dependency / how to review

> **This PR is stacked on #55** (the multi-base client). It needs the `apiGroup`
> infrastructure introduced there, so its diff currently *also* includes #55's
> commit. **Please review only the banking commit here**
> (`feat(banking): add experimental bank-feed reconciliation tool`). Once #55
> merges I'll rebase this branch so only the banking changes remain.

## Changes (banking commit)

- `src/holded-client.ts` — add the `internal` API base.
- `src/tools/banking.ts` — the `reconcile_bank_transaction` tool.
- `src/validation.ts` — `reconcileBankTransactionSchema`.
- `src/index.ts` — register the tool.
- `src/__tests__/banking.test.ts`, README warning block.